### PR TITLE
re-write get_st_data_path more streamlined and better tests

### DIFF
--- a/R/get_st_data_path.R
+++ b/R/get_st_data_path.R
@@ -1,25 +1,21 @@
 #' Get the path to the required stress test auxiliary data location. Can be
 #' provided either via environment variable or options.
 #'
-#' @param envvar String. Provide the name of the environment variable that points
-#'   to the data directory/repo. Default is "ST_DATA_PATH".
-#' @param option String. If no environment variable is provided and the default
-#'   "ST_DATA_PATH" cannot be found, the function tries to get the data path
-#'   from options. In that case, provide the name of the option that points
-#'   to the data directory/repo. Default option to get the path is "st_data_path".
+#' @param var String. Provide the name of the environment variable that points
+#'   to the data directory/repo. Default is "ST_DATA_PATH". If no environment
+#'   variable is provided and the default "ST_DATA_PATH" cannot be found, the
+#'   function tries to get the data path from options. In that case, provide
+#'   the name of the option that points to the data directory/repo. Default
+#'   option to get the path is, again, "ST_DATA_PATH".
 #'
 #' @family miscellaneous utility functions
 #'
 #' @return Character
 #'
 #' @export
-get_st_data_path <- function(envvar = "ST_DATA_PATH",
-                             option = "st_data_path") {
-  if (Sys.getenv(envvar) != "") {
-    return(fs::path(Sys.getenv(envvar)))
-  } else if (!is.null(options(option)[[option]])) {
-    return(fs::path(options(option)[[option]]))
-  } else {
-    stop("Please add data path as envvar or R option")
-  }
+get_st_data_path <- function(var = "ST_DATA_PATH") {
+  path <- Sys.getenv(var, unset = getOption(var) %||% "unset")
+
+  if (path == "unset") abort("`var` is unset. Please add data path as envvar or R option.")
+  path
 }

--- a/README.Rmd
+++ b/README.Rmd
@@ -47,7 +47,7 @@ export ST_DATA_PATH="<path to data>"
 or in R:
 
 ``` r
-options("st_data_path") <- "path to data"
+options("ST_DATA_PATH") <- "path to data"
 ```
 
 **NOTE:**

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ files either as an Environment Variable or an R option using:
 or in R:
 
 ``` r
-options("st_data_path") <- "path to data"
+options("ST_DATA_PATH") <- "path to data"
 ```
 
 **NOTE:**

--- a/man/get_st_data_path.Rd
+++ b/man/get_st_data_path.Rd
@@ -5,16 +5,15 @@
 \title{Get the path to the required stress test auxiliary data location. Can be
 provided either via environment variable or options.}
 \usage{
-get_st_data_path(envvar = "ST_DATA_PATH", option = "st_data_path")
+get_st_data_path(var = "ST_DATA_PATH")
 }
 \arguments{
-\item{envvar}{String. Provide the name of the environment variable that points
-to the data directory/repo. Default is "ST_DATA_PATH".}
-
-\item{option}{String. If no environment variable is provided and the default
-"ST_DATA_PATH" cannot be found, the function tries to get the data path
-from options. In that case, provide the name of the option that points
-to the data directory/repo. Default option to get the path is "st_data_path".}
+\item{var}{String. Provide the name of the environment variable that points
+to the data directory/repo. Default is "ST_DATA_PATH". If no environment
+variable is provided and the default "ST_DATA_PATH" cannot be found, the
+function tries to get the data path from options. In that case, provide
+the name of the option that points to the data directory/repo. Default
+option to get the path is, again, "ST_DATA_PATH".}
 }
 \value{
 Character

--- a/tests/testthat/test-get_st_data_path.R
+++ b/tests/testthat/test-get_st_data_path.R
@@ -1,13 +1,19 @@
-test_that("default returns an fs path", {
-  withr::with_envvar(
-    new = c("ST_DATA_PATH" = "path/to/data"),
-    testthat::expect_s3_class(get_st_data_path(), "fs_path")
-  )
+test_that("works with `var` set as environmnetal variable", {
+  path <- "/as/envar"
+  withr::local_envvar(list(ST_DATA_PATH = path))
+
+  expect_equal(get_st_data_path(), path)
 })
 
-test_that("non existing envvar and undefined options return error", {
-  testthat::expect_error(
-    get_st_data_path(envvar = "MISSING"),
-    "Please add data path as envvar or R option"
-  )
+test_that("works with `var` set as an R option", {
+  path <- "/as/options"
+  withr::local_envvar(list(ST_DATA_PATH = NULL))
+  withr::local_options(list(ST_DATA_PATH = path))
+
+  expect_equal(get_st_data_path(), path)
+})
+
+test_that("if `var` is unset errors gracefully", {
+  withr::local_envvar(list(ST_DATA_PATH = NULL))
+  expect_error(get_st_data_path(), "var.*unset")
 })


### PR DESCRIPTION
relates to #7 

specifically: https://github.com/2DegreesInvesting/r2dii.climate.stress.test/pull/7#discussion_r644830595

Quick re-write of the function that points to the auxiliary data directory for stress testing