### PR TITLE
598 param time horizon

### DIFF
--- a/R/extend_scenario_trajectory.R
+++ b/R/extend_scenario_trajectory.R
@@ -17,14 +17,18 @@
 #'   year of the analysis.
 #' @param end_analysis Numeric. A vector of length 1 indicating the end
 #'   year of the analysis.
+#' @param time_frame Numeric. A vector of length 1 indicating the number of years
+#'   for which forward looking production data is considered.
 extend_scenario_trajectory <- function(data,
                                        scenario_data = NULL,
                                        start_analysis = NULL,
-                                       end_analysis = NULL) {
+                                       end_analysis = NULL,
+                                       time_frame = NULL) {
   force(data)
   scenario_data %||% stop("Must provide input for 'scenario_data'", call. = FALSE)
   start_analysis %||% stop("Must provide input for 'start_analysis'", call. = FALSE)
   end_analysis %||% stop("Must provide input for 'end_analysis'", call. = FALSE)
+  time_frame %||% stop("Must provide input for 'time_frame'", call. = FALSE)
 
   data_has_expected_columns <- all(
     c(
@@ -52,7 +56,7 @@ extend_scenario_trajectory <- function(data,
       .data$scen_tech_prod
     ) %>%
     # TODO: explain magic number
-    dplyr::filter(.data$year <= .env$start_analysis + 5) %>%
+    dplyr::filter(.data$year <= .env$start_analysis + .env$time_frame) %>%
     tidyr::complete(
       year = seq(.env$start_analysis, .env$end_analysis),
       tidyr::nesting(

--- a/R/set_tech_trajectories.R
+++ b/R/set_tech_trajectories.R
@@ -159,6 +159,8 @@ calc_future_prod_follows_scen <- function(planned_prod = .data$plan_tech_prod,
 #'   start year of the analysis.
 #' @param end_year Numeric. A numeric vector of length 1 that contains the
 #'   end year of the analysis.
+#' @param analysis_time_frame Numeric. A vector of length 1 indicating the number
+#'   of years for which forward looking production data is considered.
 #'
 #' @family scenario definition
 #'
@@ -172,7 +174,10 @@ set_ls_trajectory <- function(data,
                               overshoot_method = TRUE,
                               scenario_to_follow_ls_aligned = "SDS",
                               start_year = 2020,
-                              end_year = 2040) {
+                              end_year = 2040,
+                              analysis_time_frame = NULL) {
+  analysis_time_frame %||% stop("Must provide input for 'time_frame'", call. = FALSE)
+
   year_of_shock <- shock_scenario$year_of_shock
   duration_of_shock <- shock_scenario$duration_of_shock
 
@@ -271,7 +276,8 @@ set_ls_trajectory <- function(data,
           scenario_change_baseline = .data$scenario_change_baseline,
           scenario_change_aligned = .data$scenario_change_aligned,
           overshoot_method = overshoot_method,
-          overshoot_direction = .data$overshoot_direction[1]
+          overshoot_direction = .data$overshoot_direction[1],
+          time_frame = .env$analysis_time_frame
         )
       )
     ) %>%
@@ -348,6 +354,8 @@ set_ls_trajectory <- function(data,
 #'   the technology at hand is increasing or decreasing over the time frame of
 #'   the analysis.
 #'   TODO: (move to data argument)
+#' @param time_frame Numeric. A vector of length 1 indicating the number of years
+#'   for which forward looking production data is considered.
 #'
 #' @family scenario definition
 #'
@@ -366,7 +374,10 @@ calc_late_sudden_traj <- function(start_year = 2020,
                                   scenario_change_baseline = .data$scenario_change_baseline,
                                   scenario_change_aligned = .data$scenario_change_aligned,
                                   overshoot_method = TRUE,
-                                  overshoot_direction = .data$overshoot_direction[1]) {
+                                  overshoot_direction = .data$overshoot_direction[1],
+                                  time_frame = NULL) {
+  time_frame %||% stop("Must provide input for 'time_frame'", call. = FALSE)
+
   # calculate the position where the shock kicks in
   position_shock_year <- year_of_shock - start_year + 1
 
@@ -396,10 +407,10 @@ calc_late_sudden_traj <- function(start_year = 2020,
     # the LS trajectory equal to the SDS trajectory
     if ((
       overshoot_direction == "Decreasing" &
-        sum(scen_to_follow[1:5]) < sum(late_and_sudden[1:5])
+        sum(scen_to_follow[1:time_frame]) < sum(late_and_sudden[1:time_frame])
     ) | (
       overshoot_direction == "Increasing" &
-        sum(scen_to_follow[1:5]) > sum(late_and_sudden[1:5])
+        sum(scen_to_follow[1:time_frame]) > sum(late_and_sudden[1:time_frame])
     )
     ) {
       x <- (sum(scen_to_follow) -

--- a/man/calc_late_sudden_traj.Rd
+++ b/man/calc_late_sudden_traj.Rd
@@ -18,7 +18,8 @@ calc_late_sudden_traj(
   scenario_change_baseline = .data$scenario_change_baseline,
   scenario_change_aligned = .data$scenario_change_aligned,
   overshoot_method = TRUE,
-  overshoot_direction = .data$overshoot_direction[1]
+  overshoot_direction = .data$overshoot_direction[1],
+  time_frame = NULL
 )
 }
 \arguments{
@@ -82,6 +83,9 @@ sizes need to be supplied by the user.}
 the technology at hand is increasing or decreasing over the time frame of
 the analysis.
 TODO: (move to data argument)}
+
+\item{time_frame}{Numeric. A vector of length 1 indicating the number of years
+for which forward looking production data is considered.}
 }
 \value{
 numeric vector

--- a/man/extend_scenario_trajectory.Rd
+++ b/man/extend_scenario_trajectory.Rd
@@ -14,7 +14,8 @@ extend_scenario_trajectory(
   data,
   scenario_data = NULL,
   start_analysis = NULL,
-  end_analysis = NULL
+  end_analysis = NULL,
+  time_frame = NULL
 )
 }
 \arguments{
@@ -32,6 +33,9 @@ year of the analysis.}
 
 \item{end_analysis}{Numeric. A vector of length 1 indicating the end
 year of the analysis.}
+
+\item{time_frame}{Numeric. A vector of length 1 indicating the number of years
+for which forward looking production data is considered.}
 }
 \description{
 Extend the scenario pathways based on the fair share approach (now known as

--- a/man/set_ls_trajectory.Rd
+++ b/man/set_ls_trajectory.Rd
@@ -13,7 +13,8 @@ set_ls_trajectory(
   overshoot_method = TRUE,
   scenario_to_follow_ls_aligned = "SDS",
   start_year = 2020,
-  end_year = 2040
+  end_year = 2040,
+  analysis_time_frame = NULL
 )
 }
 \arguments{
@@ -48,6 +49,9 @@ start year of the analysis.}
 
 \item{end_year}{Numeric. A numeric vector of length 1 that contains the
 end year of the analysis.}
+
+\item{analysis_time_frame}{Numeric. A vector of length 1 indicating the number
+of years for which forward looking production data is considered.}
 }
 \value{
 data frame

--- a/stress_test_model_eq_cb.R
+++ b/stress_test_model_eq_cb.R
@@ -99,7 +99,7 @@ cfg <- config::get(file = file.path(project_location, "10_Parameter_File","Analy
 # OPEN: check_valid_cfg() not applicable here
 start_year <- cfg$AnalysisPeriod$Years.Startyear
 dataprep_timestamp <- cfg$TimeStamps$DataPrep.Timestamp # is this being used for anything???
-
+time_horizon <- cfg$AnalysisPeriod$Years.Horizon
 
 ##### Filters----------------------------------------
 # The filter settings should comply with the filters from the parent PACTA project as per default
@@ -346,7 +346,7 @@ if (identical(calculation_level, "company")) {nesting_vars <- c(nesting_vars, "c
 portcheck_portresults_bonds <- portcheck_portresults_bonds_full %>%
   mutate(scenario = str_replace(scenario, "NPSRTS", "NPS")) %>%
   tidyr::complete(
-    year = seq(start_year, start_year + 5),
+    year = seq(start_year, start_year + time_horizon),
     nesting(!!!syms(nesting_vars))
   ) %>%
   mutate(plan_tech_prod = dplyr::if_else(is.na(plan_tech_prod), 0, plan_tech_prod)) %>%
@@ -375,7 +375,7 @@ check_scenario_availability(
 portcheck_portresults_equity <- portcheck_portresults_equity_full %>%
   mutate(scenario = str_replace(scenario, "NPSRTS", "NPS")) %>%
   tidyr::complete(
-    year = seq(start_year, start_year + 5),
+    year = seq(start_year, start_year + time_horizon),
     nesting(!!!syms(nesting_vars))
   ) %>%
   mutate(plan_tech_prod = dplyr::if_else(is.na(plan_tech_prod), 0, plan_tech_prod)) %>%
@@ -479,7 +479,8 @@ for (i in seq(1, nrow(transition_scenarios))) {
     extend_scenario_trajectory(
       scenario_data = scenario_data,
       start_analysis = start_year,
-      end_analysis = end_year
+      end_analysis = end_year,
+      time_frame = time_horizon
     ) %>%
     set_baseline_trajectory(
       scenario_to_follow_baseline = scenario_to_follow_baseline,
@@ -492,7 +493,8 @@ for (i in seq(1, nrow(transition_scenarios))) {
       overshoot_method = overshoot_method,
       scenario_to_follow_ls_aligned = scenario_to_follow_ls_aligned,
       start_year = start_year,
-      end_year = end_year
+      end_year = end_year,
+      analysis_time_frame = time_horizon
     )
 
   if (exists("excluded_companies")) {
@@ -634,7 +636,8 @@ for (i in seq(1, nrow(transition_scenarios))) {
     extend_scenario_trajectory(
       scenario_data = scenario_data,
       start_analysis = start_year,
-      end_analysis = end_year
+      end_analysis = end_year,
+      time_frame = time_horizon
     ) %>%
     set_baseline_trajectory(
       scenario_to_follow_baseline = scenario_to_follow_baseline,
@@ -647,7 +650,8 @@ for (i in seq(1, nrow(transition_scenarios))) {
       overshoot_method = overshoot_method,
       scenario_to_follow_ls_aligned = scenario_to_follow_ls_aligned,
       start_year = start_year,
-      end_year = end_year
+      end_year = end_year,
+      analysis_time_frame = time_horizon
     )
 
   if (exists("excluded_companies")) {

--- a/stress_test_model_loan_book.R
+++ b/stress_test_model_loan_book.R
@@ -102,7 +102,7 @@ cfg <- config::get(file = file.path(project_location, "10_Parameter_File","Analy
 # OPEN: check_valid_cfg() not applicable here
 start_year <- cfg$AnalysisPeriod$Years.Startyear
 dataprep_timestamp <- cfg$TimeStamps$DataPrep.Timestamp # is this being used for anything???
-
+time_horizon <- cfg$AnalysisPeriod$Years.Horizon
 
 ##### Filters----------------------------------------
 # The filter settings should comply with the filters from the parent PACTA project as per default
@@ -480,7 +480,8 @@ for (i in seq(1, nrow(transition_scenarios))) {
     extend_scenario_trajectory(
       scenario_data = scenario_data,
       start_analysis = start_year,
-      end_analysis = end_year
+      end_analysis = end_year,
+      time_frame = time_horizon
     ) %>%
     set_baseline_trajectory(
       scenario_to_follow_baseline = scenario_to_follow_baseline,
@@ -493,7 +494,8 @@ for (i in seq(1, nrow(transition_scenarios))) {
       overshoot_method = overshoot_method,
       scenario_to_follow_ls_aligned = scenario_to_follow_ls_aligned,
       start_year = start_year,
-      end_year = end_year
+      end_year = end_year,
+      analysis_time_frame = time_horizon
     )
 
   if (exists("excluded_companies")) {

--- a/tests/testthat/test-extend_scenario_trajectory.R
+++ b/tests/testthat/test-extend_scenario_trajectory.R
@@ -11,12 +11,14 @@ test_that("with missing argument for scenario_data, extend_scenario_trajectory
 
   test_start <- 2020
   test_end <- 2040
+  test_horizon <- 5
 
   testthat::expect_error(
     extend_scenario_trajectory(
       data = test_data,
       start_analysis = test_start,
-      end_analysis = test_end
+      end_analysis = test_end,
+      time_frame = test_horizon
     ),
     "Must provide input for 'scenario_data'"
   )
@@ -29,12 +31,14 @@ test_that("scenario data after extension equal production in start year times
 
   test_start <- 2020
   test_end <- 2040
+  test_horizon <- 5
 
   test_results <- extend_scenario_trajectory(
     data = test_data,
     scenario_data = test_scenario,
     start_analysis = test_start,
-    end_analysis = test_end
+    end_analysis = test_end,
+    time_frame = test_horizon
   )
 
   verify_technology <- "Electric"

--- a/tests/testthat/test-set_tech_trajectories.R
+++ b/tests/testthat/test-set_tech_trajectories.R
@@ -127,7 +127,8 @@ test_that("set_ls_trajectory returns a data frame", {
     overshoot_method = TRUE,
     scenario_to_follow_ls_aligned = "SDS",
     start_year = 2020,
-    end_year = 2040
+    end_year = 2040,
+    analysis_time_frame = 5
   )
 
   testthat::expect_s3_class(ls_trajectory, "data.frame")
@@ -148,7 +149,8 @@ test_that("set_ls_trajectory fully replicates baseline until year before shock,
       overshoot_method = TRUE,
       scenario_to_follow_ls_aligned = "SDS",
       start_year = 2020,
-      end_year = 2040
+      end_year = 2040,
+      analysis_time_frame = 5
     ) %>%
     dplyr::filter(.data$year < year_of_shock & .data$technology == "Coal")
 
@@ -173,7 +175,8 @@ test_that("when technology is aligned, set_ls_trajectory fully replicates
     overshoot_method = TRUE,
     scenario_to_follow_ls_aligned = "SDS",
     start_year = 2020,
-    end_year = 2040
+    end_year = 2040,
+    analysis_time_frame = 5
   ) %>%
   dplyr::filter(.data$technology == "Electric" & .data$year < year_of_shock) %>%
   dplyr::mutate(

--- a/web_tool_stress_test.R
+++ b/web_tool_stress_test.R
@@ -294,7 +294,7 @@ if (file.exists(file.path(results_path, pf_name, paste0("Equity_results_", calcu
 
   portcheck_portresults_equity <- portcheck_portresults_equity_full %>%
     tidyr::complete(
-      year = seq(start_year, start_year + 5),
+      year = seq(start_year, start_year + time_horizon),
       nesting(!!!syms(nesting_vars))
     ) %>%
     mutate(plan_tech_prod = dplyr::if_else(is.na(plan_tech_prod), 0, plan_tech_prod)) %>%
@@ -374,7 +374,8 @@ if (file.exists(file.path(results_path, pf_name, paste0("Equity_results_", calcu
         extend_scenario_trajectory(
           scenario_data = scenario_data,
           start_analysis = start_year,
-          end_analysis = end_year
+          end_analysis = end_year,
+          time_frame = time_horizon
         ) %>%
         set_baseline_trajectory(
           scenario_to_follow_baseline = scenario_to_follow_baseline,
@@ -387,7 +388,8 @@ if (file.exists(file.path(results_path, pf_name, paste0("Equity_results_", calcu
           overshoot_method = overshoot_method,
           scenario_to_follow_ls_aligned = scenario_to_follow_ls_aligned,
           start_year = start_year,
-          end_year = end_year
+          end_year = end_year,
+          analysis_time_frame = time_horizon
         )
 
       if (exists("excluded_companies")) {
@@ -485,7 +487,7 @@ if (file.exists(file.path(results_path, pf_name, paste0("Bonds_results_", calcul
 
   portcheck_portresults_bonds <- portcheck_portresults_bonds_full %>%
     tidyr::complete(
-      year = seq(start_year, start_year + 5),
+      year = seq(start_year, start_year + time_horizon),
       nesting(!!!syms(nesting_vars))
     ) %>%
     mutate(plan_tech_prod = dplyr::if_else(is.na(plan_tech_prod), 0, plan_tech_prod)) %>%
@@ -562,7 +564,8 @@ if (file.exists(file.path(results_path, pf_name, paste0("Bonds_results_", calcul
         extend_scenario_trajectory(
           scenario_data = scenario_data,
           start_analysis = start_year,
-          end_analysis = end_year
+          end_analysis = end_year,
+          time_frame = time_horizon
         ) %>%
         set_baseline_trajectory(
           scenario_to_follow_baseline = scenario_to_follow_baseline,
@@ -575,7 +578,8 @@ if (file.exists(file.path(results_path, pf_name, paste0("Bonds_results_", calcul
           overshoot_method = overshoot_method,
           scenario_to_follow_ls_aligned = scenario_to_follow_ls_aligned,
           start_year = start_year,
-          end_year = end_year
+          end_year = end_year,
+          analysis_time_frame = time_horizon
         )
 
       if (exists("excluded_companies")) {


### PR DESCRIPTION
closes ADO https://dev.azure.com/2DegreesInvesting/2DegreesInvesting/_workitems/edit/598

This PR:
- uses the time_horizon parameter from the `AnalysisParameters.yml` (offline) or `ProjectParameters.yml` (web tool) config files throughout all functions and work flows
- updates function definitions, documentation and tests accordingly
- removes the corresponding magic numbers, usually 5
- thereby let's the user control the number of years of forward looking production data used without changing anything code side