### PR TITLE
488 connect web tool with new repo

### DIFF
--- a/web_tool_external_stress_test.R
+++ b/web_tool_external_stress_test.R
@@ -36,6 +36,8 @@ setup_project()
 
 #### Project location----------------------------------------
 
+data_location <- file.path(get_st_data_path(), data_path())
+
 # Parameters passed from PACTA_analysis web_tool_script_2.R
 pf_name <- portfolio_name_ref_all
 investor_name_filter <- investor_name
@@ -100,7 +102,7 @@ if (file.exists(file.path(results_path, pf_name, "Equity_results_portfolio.rda")
 
 # load external shock data
 shocks <-
-  readr::read_csv(file.path(stress_test_path, data_path("external_stress_test_shocks.csv")),
+  readr::read_csv(file.path(data_location, "external_stress_test_shocks.csv"),
     na = c("", "NA", "#VALUE!"), col_types = cols()
   )
 
@@ -204,9 +206,10 @@ if (exists("portfolio")) {
 # if(exists("results_dnb")){
 #   results_dnb %>% readr::write_csv(file.path(results_path,pf_name,"Stress_test_results_DNB.csv"))
 # } else {"No Stress Test results available for DNB Scenarios"}
-if (exists("results_ipr") &
-    any(unique(results_ipr$sector) != "Other")) {
-  results_ipr %>% readr::write_rds(file.path(results_path, pf_name, "Stress_test_results_IPR.rds"))
+if (exists("results_ipr")) {
+  if (any(unique(results_ipr$sector) != "Other")) {
+    results_ipr %>% readr::write_rds(file.path(results_path, pf_name, "Stress_test_results_IPR.rds"))
+  }
 } else {
   "No Stress Test results available for IPR FPS Scenario"
 }

--- a/web_tool_external_stress_test.R
+++ b/web_tool_external_stress_test.R
@@ -76,7 +76,6 @@ if (file.exists(file.path(proc_input_path, pf_name, "total_portfolio.rda")) &
 }
 
 
-
 # load portfolio results, get the plan_carsten values at start year, join in portfolio size and multiply with plan_carsten to get tech
 if (file.exists(file.path(results_path, pf_name, "Bonds_results_portfolio.rda"))) {
   cb_exposures <- read_rds(file.path(results_path, pf_name, "Bonds_results_portfolio.rda")) %>%
@@ -106,69 +105,7 @@ shocks <-
     na = c("", "NA", "#VALUE!"), col_types = cols()
   )
 
-
-
-
 # Calculate Results -----------------------------------------------------------------
-
-# NOTE: Currently we only calculate and return IPR results in the webtool. BoE and DNB are comented out, but might be added again soon
-
-# # calculate BoE exposures
-# calc_boe_exposures <- function(pacta_exposures){
-#   pacta_exposures %>%
-#     filter(ald_sector!='Other') %>%
-#     mutate(
-#       subsector = case_when(
-#         technology %in% c('RenewablesCap','HydroCap','NuclearCap') ~ "Low carbon",
-#         technology %in% c('ICE','Hybrid','FuelCell') ~ "Non electric",
-#         technology %in% c('Electric') ~ "Electric",
-#         technology %in% c('CoalCap') ~ "Coal Power",
-#         technology %in% c('GasCap') ~ "Gas Power",
-#         technology %in% c('OilCap') ~ "Oil Power",
-#         technology %in% c('Electric') ~ "Electric",
-#
-#         ald_sector %in% c('Shipping','Aviation') ~ NA_character_,
-#         ald_sector %in% c('Cement','Steel') ~ "Fossil Fuel Based",
-#         TRUE ~ technology
-#       ),
-#       sector = case_when(
-#         ald_sector %in% c('Oil&Gas','Coal') ~ "Fuel extraction",
-#         ald_sector %in% c('Steel','Cement') ~ "Materials",
-#         TRUE ~ ald_sector
-#       )) %>%
-#     group_by(investor_name,portfolio_name,sector,subsector) %>%
-#     summarise(exposure = sum(tech_exposure,na.rm=T),
-#               .groups = "drop_last")
-# }
-#
-# #FIXME: Produce empty tibble if one of the asset types is missing
-# if(exists("cb_exposures")){boe_exposures_cb <- calc_boe_exposures(cb_exposures) %>% mutate(asset_type='Bonds')}
-# if(exists("eq_exposures")){boe_exposures_eq <- calc_boe_exposures(eq_exposures) %>% mutate(asset_type='Equity')}
-#
-# # calculate BoE results
-# results_boe <- portfolio %>%
-#   as.data.frame() %>%
-#   filter(asset_type %in% c('Equity','Bonds'),sector_boe %in% c('Agriculture','Food logistics','Real estate','Materials')) %>%
-#   group_by(investor_name,portfolio_name,sector_boe,subsector_boe,asset_type) %>%
-#   summarise(exposure = sum(value_usd,na.rm=TRUE),
-#             .groups = "drop_last") %>%
-#   rename(sector=sector_boe,subsector=subsector_boe) %>%
-#   bind_rows(boe_exposures_cb,boe_exposures_eq) %>%
-#   left_join(shocks %>% filter(methodology=='BoE') %>% select(-c(description,methodology)),by=c('sector','subsector')) %>%
-#   mutate(shock=ifelse(asset_type=='Bonds',0.15*shock,shock),
-#          loss = exposure * shock/100)
-#
-# #FIXME: If result is empty, what to return?
-# # calculate DNB results
-# results_dnb <- portfolio %>%
-#   as.data.frame() %>%
-#   filter(asset_type=='Equity') %>%
-#   group_by(investor_name,portfolio_name,sector_dnb) %>%
-#   summarise(exposure = sum(value_usd,na.rm=TRUE),
-#             .groups = "drop_last") %>%
-#   rename(sector = sector_dnb) %>%
-#   left_join(shocks %>% filter(methodology=='DNB') %>% select(-c(methodology)),by=c('sector')) %>%
-#   mutate(loss = exposure * shock/100)
 
 # FIXME: If result is empty, what to return?
 # calculate IPR results
@@ -198,14 +135,6 @@ if (exists("portfolio")) {
 
 # Write Results -----------------------------------------------------------------
 
-# NOTE: Currently we only calculate and return IPR results in the webtool. BoE and DNB are comented out, but might be added again soon
-
-# if(exists("results_boe")){
-#   results_boe %>% readr::write_csv(file.path(results_path,pf_name,"Stress_test_results_BOE.csv"))
-# } else {"No Stress Test results available for BoE Scenarios"}
-# if(exists("results_dnb")){
-#   results_dnb %>% readr::write_csv(file.path(results_path,pf_name,"Stress_test_results_DNB.csv"))
-# } else {"No Stress Test results available for DNB Scenarios"}
 if (exists("results_ipr")) {
   if (any(unique(results_ipr$sector) != "Other")) {
     results_ipr %>% readr::write_rds(file.path(results_path, pf_name, "Stress_test_results_IPR.rds"))

--- a/web_tool_stress_test.R
+++ b/web_tool_stress_test.R
@@ -60,9 +60,7 @@ setup_project()
 
 #### Project location----------------------------------------
 
-# TODO: ensure this is updated to point to r2dii.stress.test.data
-# TODO: stress_test_path probably won't work anymore for loading data. Replace!
-data_location <- file.path(working_location, data_path())
+data_location <- file.path(get_st_data_path(), data_path())
 
 # Parameters passed from PACTA_analysis web_tool_script_2.R
 pf_name <- portfolio_name_ref_all
@@ -184,7 +182,7 @@ sector_exposures <- readRDS(file.path(proc_input_path, pf_name, "overview_portfo
 
 # Load transition scenarios that will be run by the model
 transition_scenarios <- read_transition_scenarios(
-  path = file.path(stress_test_path, data_path("project_transition_scenarios", glue::glue("transition_scenario_{project_code}.csv"))),
+  path = file.path(data_location, "project_transition_scenarios", glue::glue("transition_scenario_{project_code}.csv")),
   start_of_analysis = start_year,
   end_of_analysis = end_year
 )
@@ -199,7 +197,7 @@ transition_scenarios <- read_transition_scenarios(
 # Load utilization factors power
 # TODO: replace with new capacity factors
 capacity_factors_power <- read_capacity_factors(
-  path = file.path(stress_test_path, data_path("capacity_factors_WEO_2017.csv")),
+  path = file.path(data_location, "capacity_factors_WEO_2017.csv"),
   version = "old"
 )
 
@@ -207,7 +205,7 @@ capacity_factors_power <- read_capacity_factors(
 
 scen_data_file <- ifelse(twodii_internal == TRUE,
   path_dropbox_2dii("PortCheck", "00_Data", "01_ProcessedData", "03_ScenarioData", paste0("Scenarios_AnalysisInput_", start_year, ".csv")),
-  file.path(stress_test_path, data_path(paste0("Scenarios_AnalysisInput_", start_year, ".csv")))
+  file.path(data_location, glue::glue("Scenarios_AnalysisInput_{start_year}.csv"))
 )
 
 scenario_data <- readr::read_csv(scen_data_file, col_types = cols(.default = col_guess())) %>%
@@ -223,7 +221,7 @@ scenario_data <- scenario_data %>%
 
 # %>% filter(year %in% c(start_year,2020, 2021, 2022, 2023, 2024, 2025, 2030, 2035, 2040))
 
-df_price <- readr::read_csv(file.path(stress_test_path, data_path(paste0("prices_data_", price_data_version, ".csv"))), col_types = cols()) %>%
+df_price <- readr::read_csv(file.path(data_location, glue::glue("prices_data_{price_data_version}.csv")), col_types = cols()) %>%
   filter(year >= start_year) %>%
   check_price_consistency()
 
@@ -295,7 +293,6 @@ if (file.exists(file.path(results_path, pf_name, paste0("Equity_results_", calcu
   )
 
   pacta_equity_results_full <- pacta_equity_results_full %>%
-    select(-c(trajectory_deviation, trajectory_alignment, scen_tech_share, plan_tech_share, scen_sec_emissions_factor, scen_sec_carsten, scen_alloc_wt_sec_prod, scen_sec_prod, plan_sec_emissions_factor, scen_emission_factor, scen_carsten, plan_emission_factor)) %>%
     filter(scenario %in% scenarios) %>%
     mutate(scenario = ifelse(str_detect(scenario, "_"), str_extract(scenario, "[^_]*$"), scenario)) %>%
     check_portfolio_consistency()
@@ -495,7 +492,6 @@ if (file.exists(file.path(results_path, pf_name, paste0("Bonds_results_", calcul
   )
 
   pacta_bonds_results_full <- pacta_bonds_results_full %>%
-    select(-c(trajectory_deviation, trajectory_alignment, scen_tech_share, plan_tech_share, scen_sec_emissions_factor, scen_sec_carsten, scen_alloc_wt_sec_prod, scen_sec_prod, plan_sec_emissions_factor, scen_emission_factor, scen_carsten, plan_emission_factor)) %>%
     filter(scenario %in% scenarios) %>%
     mutate(scenario = ifelse(str_detect(scenario, "_"), str_extract(scenario, "[^_]*$"), scenario)) %>%
     check_portfolio_consistency()


### PR DESCRIPTION
closes ADO 488 https://dev.azure.com/2DegreesInvesting/2DegreesInvesting/_workitems/edit/488

This PR:
- assumes the variable `stress_test_path` that used to point to `../StressTestingModelDev/` (local) or `/StressTestingModelDev/` (docker) now points to the new repo `../r2dii.climate.stress.test/` (local) or `/r2dii.climate.stress.test/` (docker)
- it assumes that en environment variable `ST_DATA_PATH` is set that points to `../r2dii.stress.test.data/` (local) or `/r2dii.stress.test.data/` (docker)
- uses the function get_st_data_path() to set the data location within the web scripts `web_tool_stress_test.R` and `web_tool_external_stress_test.R`
- removes a select that is now covered by a dedicated function that reads in data