### PR TITLE
884 basel lgd

### DIFF
--- a/.github/workflows/pr-check-file-encodings.yaml
+++ b/.github/workflows/pr-check-file-encodings.yaml
@@ -1,7 +1,8 @@
 name: check file encodings in PR
 on: [pull_request]
 jobs:
-  build:
+  file-encoding:
+    name: file encooding check
     runs-on: ubuntu-latest
 
     steps:
@@ -18,4 +19,4 @@ jobs:
         run: |
           files=$(git diff --name-only origin/$GITHUB_BASE_REF...${{ github.sha }})
           IFS=$'\n'; files=($files); unset IFS;  # split the string into an array
-          ! file --mime "${files[@]}" | grep -v "charset=utf-8\|charset=us-ascii\|charset=binary"
+          ! file --mime "${files[@]}" | grep -v "charset=utf-8\|charset=us-ascii\|charset=binary\| (No such file or directory)$"

--- a/R/company_expected_loss.R
+++ b/R/company_expected_loss.R
@@ -7,8 +7,9 @@
 #' future profits plus the terminal value.
 #'
 #' @param data A dataframe containing the (discounted) annual profits
-#' @param loss_given_default A dataframe containing sectoral percentages of how
-#'   large the share of lost value in a loan is, in case of default.
+#' @param loss_given_default A numeric vector of length one that indicates
+#'   the loss given default for the given asset type. Usually either a senior
+#'   claim or a subordinated claim.
 #' @param exposure_at_default A dataframe that contains the share of the
 #'   portfolio value of each company-technology combination. Used to quantify
 #'   the impact of the company-tech level shock on higher levels of aggregation
@@ -32,13 +33,6 @@ company_expected_loss <- function(data,
     ) %in% colnames(data)
   )
   stopifnot(data_has_expected_columns)
-
-  loss_given_default_has_expected_columns <- all(
-    c(
-      "sector", "lgd"
-    ) %in% colnames(loss_given_default)
-  )
-  stopifnot(loss_given_default_has_expected_columns)
 
   exposure_at_default_has_expected_columns <- all(
     c(
@@ -71,7 +65,7 @@ company_expected_loss <- function(data,
     dplyr::mutate(term = dplyr::if_else(.data$term > 5, 5, .data$term))
 
   data <- data %>%
-    dplyr::inner_join(loss_given_default, by = c("ald_sector" = "sector"))
+    dplyr::mutate(lgd = loss_given_default)
 
   data <- data %>%
     dplyr::left_join(

--- a/man/company_expected_loss.Rd
+++ b/man/company_expected_loss.Rd
@@ -20,8 +20,9 @@ company_expected_loss(
 \arguments{
 \item{data}{A dataframe containing the (discounted) annual profits}
 
-\item{loss_given_default}{A dataframe containing sectoral percentages of how
-large the share of lost value in a loan is, in case of default.}
+\item{loss_given_default}{A numeric vector of length one that indicates
+the loss given default for the given asset type. Usually either a senior
+claim or a subordinated claim.}
 
 \item{exposure_at_default}{A dataframe that contains the share of the
 portfolio value of each company-technology combination. Used to quantify

--- a/model_parameters.yml
+++ b/model_parameters.yml
@@ -8,6 +8,8 @@ default:
     div_netprofit_prop_coef: 1
     terminal_value: 0
     risk_free_rate: 0.0129 # US 10Y treasury rate
+    lgd_senior_claims: 0.45
+    lgd_subordinated_claims: 0.75
 
   scenarios:
     scenario_to_follow_baseline: NPS

--- a/stress_test_model_eq_cb.R
+++ b/stress_test_model_eq_cb.R
@@ -179,6 +179,8 @@ discount_rate <- cfg_mod$financials$discount_rate # Discount rate
 terminal_value <- cfg_mod$financials$terminal_value
 div_netprofit_prop_coef <- cfg_mod$financials$div_netprofit_prop_coef # determine this value using bloomberg data
 risk_free_rate <- cfg_mod$financials$risk_free_rate
+lgd_senior_claims <- cfg_mod$financials$lgd_senior_claims
+lgd_subordinated_claims <- cfg_mod$financials$lgd_subordinated_claims
 
 
 ###########################################################################
@@ -912,7 +914,7 @@ for (i in seq(1, nrow(transition_scenarios))) {
         bonds_expected_loss,
         company_expected_loss(
           data = bonds_overall_pd_changes,
-          loss_given_default = lgd_by_sector,
+          loss_given_default = lgd_subordinated_claims,
           exposure_at_default = plan_carsten_bonds,
           # TODO: what to do with this? some sector level exposure for loanbook?
           port_aum = bonds_port_aum
@@ -956,7 +958,7 @@ for (i in seq(1, nrow(transition_scenarios))) {
         bonds_expected_loss,
         company_expected_loss(
           data = bonds_overall_pd_changes,
-          loss_given_default = lgd_by_sector,
+          loss_given_default = lgd_subordinated_claims,
           exposure_at_default = plan_carsten_bonds,
           # TODO: what to do with this? some sector level exposure for loanbook?
           port_aum = bonds_port_aum

--- a/stress_test_model_loan_book.R
+++ b/stress_test_model_loan_book.R
@@ -183,6 +183,8 @@ discount_rate <- cfg_mod$financials$discount_rate # Discount rate
 terminal_value <- cfg_mod$financials$terminal_value
 div_netprofit_prop_coef <- cfg_mod$financials$div_netprofit_prop_coef # determine this value using bloomberg data
 risk_free_rate <- cfg_mod$financials$risk_free_rate
+lgd_senior_claims <- cfg_mod$financials$lgd_senior_claims
+lgd_subordinated_claims <- cfg_mod$financials$lgd_subordinated_claims
 
 # technology net profit margins
 ## the parameters should be outsorced into a config file at some point
@@ -574,7 +576,7 @@ for (i in seq(1, nrow(transition_scenarios))) {
       loanbook_expected_loss,
       company_expected_loss(
         data = loanbook_overall_pd_changes,
-        loss_given_default = lgd_by_sector,
+        loss_given_default = lgd_senior_claims,
         exposure_at_default = plan_carsten_loanbook,
         # TODO: what to do with this? some sector level exposure for loanbook?
         port_aum = loan_book_port_aum
@@ -621,7 +623,7 @@ for (i in seq(1, nrow(transition_scenarios))) {
       loanbook_expected_loss,
       company_expected_loss(
         data = loanbook_overall_pd_changes,
-        loss_given_default = lgd_by_sector,
+        loss_given_default = lgd_senior_claims,
         exposure_at_default = plan_carsten_loanbook,
         # TODO: what to do with this? some sector level exposure for loanbook?
         port_aum = loan_book_port_aum

--- a/tests/testthat/test-company_expected_loss.R
+++ b/tests/testthat/test-company_expected_loss.R
@@ -24,7 +24,7 @@ test_that("with missing argument for loss_given_default, company_expected_loss
 test_that("with missing argument for shock_year, calculate_pd_change throws
           error", {
   test_data <- read_test_data("loanbook_overall_pd_changes.csv")
-  test_lgd <- read_test_data("loss_given_default_by_sector.csv")
+  test_lgd <- 0.45
   test_ead <- read_test_data("loanbook_exposure_at_default.csv")
   test_port_aum <- read_test_data("loanbook_aum.csv")
 
@@ -40,7 +40,7 @@ test_that("with missing argument for shock_year, calculate_pd_change throws
 
 test_that("expected losses point in correct direction", {
   test_data <- read_test_data("loanbook_overall_pd_changes.csv")
-  test_lgd <- read_test_data("loss_given_default_by_sector.csv")
+  test_lgd <- 0.45
   test_ead <- read_test_data("loanbook_exposure_at_default.csv")
   test_port_aum <- read_test_data("loanbook_aum.csv")
 

--- a/tests/testthat/test_data/loss_given_default_by_sector.csv
+++ b/tests/testthat/test_data/loss_given_default_by_sector.csv
@@ -1,5 +1,0 @@
-sector,lgd
-Coal,0.5
-Oil&Gas,0.45
-Power,0.35
-Automotive,0.3


### PR DESCRIPTION
closes ADO 884 https://dev.azure.com/2DegreesInvesting/2DegreesInvesting/_workitems/edit/884

This PR:
- adds two new parameters to `model_parameters.yml`: `lgd_senior_claims` and `lgd_subordinated_claims`. Both are based on the Basel framework per default.
- These parameters are passed to the `company_expected_loss()` function instead of sectoral placeholder LGDs
- as per default, bonds get the `lgd_subordinated_claims` parameter whereas loans get `lgd_senior_claims`
- the `company_expected_loss()` function is adjusted to not merge sectoral lgds but instead create a new variable based on the input from the passed parameter.
- The test is adjusted to use parameter inputs
- The test file with placeholder sectorial LGDs is removed