### PR TITLE
read st_masterdata as rds file; allow for credit md file to be read

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -109,8 +109,9 @@ create_stressdata_masterdata_file_paths <- function(data_prep_timestamp, twodii_
   path_parent <- path_dropbox_2dii("PortCheck", "00_Data", "07_AnalysisInputs", data_prep_timestamp)
 
   paths <- list(
-    "stress_test_masterdata_debt.rda",
-    "stress_test_masterdata_ownership.rda"
+    "stress_test_masterdata_debt.rds",
+    "stress_test_masterdata_ownership.rds",
+    "stress_test_masterdata_credit.rds"
   ) %>%
     purrr::map(function(file) {
       file_path <- file.path(path_parent, file)
@@ -119,7 +120,7 @@ create_stressdata_masterdata_file_paths <- function(data_prep_timestamp, twodii_
       }
       return(file_path)
     }) %>%
-    purrr::set_names(c("bonds", "listed_equity"))
+    purrr::set_names(c("bonds", "listed_equity", "loans"))
 
   return(paths)
 }


### PR DESCRIPTION
Closes ADO 1607 https://dev.azure.com/2DegreesInvesting/2DegreesInvesting/_workitems/edit/1607

This PR:
- reads the `stress_test_master_data_*.rds` files as `rds`, not `rda`
- these files have been changed to RDS in the predecessor https://github.com/2DegreesInvesting/r2dii.stress.test.data/pull/27
- additionally the utility function create_stressdata_masterdata_file_paths() now allows for reading st master data for loans as well, by calling `read_company_data(path = stresstest_masterdata_files$loans)`