### PR TITLE
Ado 1639 prewrangled

### DIFF
--- a/R/read_company_data.R
+++ b/R/read_company_data.R
@@ -1,15 +1,23 @@
 #' Read in company finacial data processed from eikon exports and AR master data
 #' that contain information on multiple credit risk inputs and company
-#' production plans.
+#' production plans, aggregated to the ticker/technology/year level for
+#' `asset_type` bonds and aggregated to the company/technology/year level for
+#' `asset_type` equity.
 #'
 #' @param path A string that points to the location of the file containing the
 #'   company financial data.
+#' @param asset_type A string indicating if company data are for analysis for
+#'   bond or equity.
 #'
 #' @family import functions
 #'
 #' @export
-read_company_data <- function(path = NULL) {
+read_company_data <- function(path = NULL, asset_type) {
   path %||% stop("Must provide 'path'")
+
+  if (!asset_type %in% c("bond", "equity")) {
+    stop("Invalid asset type.")
+  }
 
   valid_input_file_path <- file.exists(file.path(path))
   stopifnot(valid_input_file_path)
@@ -18,31 +26,15 @@ read_company_data <- function(path = NULL) {
   data <- readRDS(path)
 
   expected_columns <- c(
-    "company_name", "company_id", "bloomberg_id", "corporate_bond_ticker",
-    "ald_location", "country_of_domicile", "is_ultimate_listed_parent",
-    "is_ultimate_parent", "parent_company_id", "ownership_level", "ald_sector",
-    "technology", "year", "ald_production", "ald_production_unit",
-    "ald_emissions_factor", "ald_emissions_factor_unit", "pd", "structural",
-    "profit_margin_preferred", "profit_margin_unpreferred", "leverage_s_avg",
-    "asset_volatility_s_avg", "asset_drift_s_avg",
-    "weighted_average_cost_of_capital_percent_s_avg", "ebitda_ltm_1_usd_s_avg",
-    "ebitda_margin_percent_ltm_1_s_avg", "indicator_type_pd",
-    "indicator_type_structural", "indicator_type_profit_margin_preferred",
-    "indicator_type_profit_margin_unpreferred", "indicator_type_leverage_s_avg",
-    "indicator_type_asset_volatility_s_avg", "indicator_type_asset_drift_s_avg",
-    "indicator_type_weighted_average_cost_of_capital_percent_s_avg",
-    "indicator_type_ebitda_ltm_1_usd_s_avg",
-    "indicator_type_ebitda_margin_percent_ltm_1_s_avg",
-    "overall_data_type_pd", "overall_data_type_structural",
-    "overall_data_type_profit_margin_preferred",
-    "overall_data_type_profit_margin_unpreferred",
-    "overall_data_type_leverage_s_avg",
-    "overall_data_type_asset_volatility_s_avg",
-    "overall_data_type_asset_drift_s_avg",
-    "overall_data_type_weighted_average_cost_of_capital_percent_s_avg",
-    "overall_data_type_ebitda_ltm_1_usd_s_avg",
-    "overall_data_type_ebitda_margin_percent_ltm_1_s_avg"
+    "company_name", "company_id", "ald_sector", "technology", "year",
+    "ald_production_unit", "ald_emissions_factor_unit", "ald_emissions_factor",
+    "pd", "profit_margin_preferred", "profit_margin_unpreferred", "leverage_s_avg",
+    "asset_volatility_s_avg", "ald_production"
   )
+
+  if (asset_type == "bond") {
+    expected_columns <- c(expected_columns, "corporate_bond_ticker")
+  }
 
   data_has_expected_columns <- all(expected_columns %in% colnames(data))
   stopifnot(data_has_expected_columns)

--- a/R/read_company_data.R
+++ b/R/read_company_data.R
@@ -13,9 +13,10 @@
 #'
 #' @export
 read_company_data <- function(path = NULL, asset_type) {
+
   path %||% stop("Must provide 'path'")
 
-  if (!asset_type %in% c("bond", "equity")) {
+  if (!asset_type %in% c("bonds", "equity")) {
     stop("Invalid asset type.")
   }
 
@@ -32,7 +33,7 @@ read_company_data <- function(path = NULL, asset_type) {
     "asset_volatility_s_avg", "ald_production"
   )
 
-  if (asset_type == "bond") {
+  if (asset_type == "bonds") {
     expected_columns <- c(expected_columns, "corporate_bond_ticker")
   }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -109,8 +109,8 @@ create_stressdata_masterdata_file_paths <- function(data_prep_timestamp, twodii_
   path_parent <- path_dropbox_2dii("PortCheck", "00_Data", "07_AnalysisInputs", data_prep_timestamp)
 
   paths <- list(
-    "stress_test_masterdata_debt.rds",
-    "stress_test_masterdata_ownership.rds",
+    "prewrangled_financial_data_bonds.rds",
+    "prewrangled_financial_data_equity.rds",
     "stress_test_masterdata_credit.rds"
   ) %>%
     purrr::map(function(file) {

--- a/man/read_company_data.Rd
+++ b/man/read_company_data.Rd
@@ -4,18 +4,25 @@
 \alias{read_company_data}
 \title{Read in company finacial data processed from eikon exports and AR master data
 that contain information on multiple credit risk inputs and company
-production plans.}
+production plans, aggregated to the ticker/technology/year level for
+\code{asset_type} bonds and aggregated to the company/technology/year level for
+\code{asset_type} equity.}
 \usage{
-read_company_data(path = NULL)
+read_company_data(path = NULL, asset_type)
 }
 \arguments{
 \item{path}{A string that points to the location of the file containing the
 company financial data.}
+
+\item{asset_type}{A string indicating if company data are for analysis for
+bond or equity.}
 }
 \description{
 Read in company finacial data processed from eikon exports and AR master data
 that contain information on multiple credit risk inputs and company
-production plans.
+production plans, aggregated to the ticker/technology/year level for
+\code{asset_type} bonds and aggregated to the company/technology/year level for
+\code{asset_type} equity.
 }
 \seealso{
 Other import functions: 

--- a/stress_test_model_eq_cb.R
+++ b/stress_test_model_eq_cb.R
@@ -192,7 +192,8 @@ stresstest_masterdata_files <- create_stressdata_masterdata_file_paths(
 )
 
 # ... for bonds----------------------------------------------------------------
-financial_data_bonds <- read_company_data(path = stresstest_masterdata_files$bonds)
+financial_data_bonds <- read_company_data(path = stresstest_masterdata_files$bonds,
+                                          asset_type = "bond")
 
 financial_data_bonds <- financial_data_bonds %>%
   dplyr::select(
@@ -237,7 +238,8 @@ financial_data_bonds <- financial_data_bonds %>%
   )
 
 # ... for equity---------------------------------------------------------------
-financial_data_equity <- read_company_data(path = stresstest_masterdata_files$listed_equity)
+financial_data_equity <- read_company_data(path = stresstest_masterdata_files$listed_equity,
+                                           asset_type = "equity")
 
 financial_data_equity <- financial_data_equity %>%
   dplyr::select(

--- a/stress_test_model_eq_cb.R
+++ b/stress_test_model_eq_cb.R
@@ -193,7 +193,7 @@ stresstest_masterdata_files <- create_stressdata_masterdata_file_paths(
 
 # ... for bonds----------------------------------------------------------------
 financial_data_bonds <- read_company_data(path = stresstest_masterdata_files$bonds,
-                                          asset_type = "bond")
+                                          asset_type = "bonds")
 
 financial_data_bonds <- financial_data_bonds %>%
   dplyr::select(

--- a/stress_test_model_eq_cb.R
+++ b/stress_test_model_eq_cb.R
@@ -195,93 +195,9 @@ stresstest_masterdata_files <- create_stressdata_masterdata_file_paths(
 financial_data_bonds <- read_company_data(path = stresstest_masterdata_files$bonds,
                                           asset_type = "bonds")
 
-financial_data_bonds <- financial_data_bonds %>%
-  dplyr::select(
-    -c(
-      tidyr::starts_with("indicator_"),
-      tidyr::starts_with("overall_data_type_")
-    )
-  )
-
-# ... aggregate to the ticker/technology/year level
-financial_data_bonds <- financial_data_bonds %>%
-  dplyr::select(
-    company_name, company_id, ald_sector, technology, year,
-    corporate_bond_ticker, ald_production, ald_production_unit,
-    ald_emissions_factor, ald_emissions_factor_unit, pd,
-    profit_margin_preferred, profit_margin_unpreferred, leverage_s_avg,
-    asset_volatility_s_avg
-  ) %>%
-  group_by(
-    company_name, company_id, corporate_bond_ticker, ald_sector, technology,
-    year, ald_production_unit, ald_emissions_factor_unit
-  ) %>%
-  summarise(
-    ald_emissions_factor = weighted.mean(ald_emissions_factor, ald_production, na.rm = TRUE),
-    pd = weighted.mean(pd, ald_production, na.rm = TRUE),
-    profit_margin_preferred = weighted.mean(profit_margin_preferred, ald_production, na.rm = TRUE),
-    profit_margin_unpreferred = weighted.mean(profit_margin_unpreferred, ald_production, na.rm = TRUE),
-    leverage_s_avg = weighted.mean(leverage_s_avg, ald_production, na.rm = TRUE),
-    asset_volatility_s_avg = weighted.mean(asset_volatility_s_avg, ald_production, na.rm = TRUE),
-    ald_production = sum(ald_production, na.rm = TRUE),
-    .groups = "drop"
-  ) %>%
-  ungroup() %>%
-  mutate(
-    across(
-      c(
-        ald_production, ald_emissions_factor, pd, profit_margin_preferred,
-        profit_margin_unpreferred, leverage_s_avg, asset_volatility_s_avg
-      ),
-      ~ round(.x, 8)
-    )
-  )
-
 # ... for equity---------------------------------------------------------------
 financial_data_equity <- read_company_data(path = stresstest_masterdata_files$listed_equity,
                                            asset_type = "equity")
-
-financial_data_equity <- financial_data_equity %>%
-  dplyr::select(
-    -c(
-      tidyr::starts_with("indicator_"),
-      tidyr::starts_with("overall_data_type_")
-    )
-  )
-
-# ... aggregate to the company/technology/year level
-financial_data_equity <- financial_data_equity %>%
-  dplyr::select(
-    company_name, company_id, ald_sector, technology, year,
-    ald_production, ald_production_unit, ald_emissions_factor,
-    ald_emissions_factor_unit, pd, profit_margin_preferred,
-    profit_margin_unpreferred, leverage_s_avg, asset_volatility_s_avg
-  ) %>%
-  group_by(
-    company_name, company_id, ald_sector, technology, year, ald_production_unit,
-    ald_emissions_factor_unit
-  ) %>%
-  summarise(
-    ald_emissions_factor = weighted.mean(ald_emissions_factor, ald_production, na.rm = TRUE),
-    pd = weighted.mean(pd, ald_production, na.rm = TRUE),
-    profit_margin_preferred = weighted.mean(profit_margin_preferred, ald_production, na.rm = TRUE),
-    profit_margin_unpreferred = weighted.mean(profit_margin_unpreferred, ald_production, na.rm = TRUE),
-    leverage_s_avg = weighted.mean(leverage_s_avg, ald_production, na.rm = TRUE),
-    asset_volatility_s_avg = weighted.mean(asset_volatility_s_avg, ald_production, na.rm = TRUE),
-    ald_production = sum(ald_production, na.rm = TRUE),
-    .groups = "drop"
-  ) %>%
-  ungroup() %>%
-  mutate(
-    across(
-      c(
-        ald_production, ald_emissions_factor, pd, profit_margin_preferred,
-        profit_margin_unpreferred, leverage_s_avg, asset_volatility_s_avg
-      ),
-      ~ round(.x, 8)
-    )
-  )
-
 
 # Load PACTA results / bonds portfolio------------------------
 bonds_path <- file.path(results_path, investorname_bonds, paste0("Bonds_results_", calculation_level, ".rda"))

--- a/tests/testthat/test-read_company_data.R
+++ b/tests/testthat/test-read_company_data.R
@@ -9,7 +9,8 @@ test_that("with all arguments set, read_company_data returns data.frame", {
   test_path <- testthat::test_path("test_data", "company_financial_and_production.rda")
 
   test_data <- read_company_data(
-    path = test_path
+    path = test_path,
+    asset_type = "bond"
   )
 
   testthat::expect_s3_class(test_data, "data.frame")

--- a/tests/testthat/test-read_company_data.R
+++ b/tests/testthat/test-read_company_data.R
@@ -10,7 +10,7 @@ test_that("with all arguments set, read_company_data returns data.frame", {
 
   test_data <- read_company_data(
     path = test_path,
-    asset_type = "bond"
+    asset_type = "bonds"
   )
 
   testthat::expect_s3_class(test_data, "data.frame")


### PR DESCRIPTION
I applied the bulk of prewrangling from the code to the masterdata sets, saved them under a new name, and removed related steps from code. This went along with a very noticable speed improvements of the scripts and also the size of the data decreased (factor 10 in R, up to factor 300 in dropbox).
I checked that datasets used in the scripts subsequently are identical to those used in master version.
I also harmonised the namings a bit and checked that no more unneeded cols are dragged along.

In this form the code should be easy to review, but I would like to suggest a few more improvements as follow up:

- if possible can we simplify the file locations to not depend on a project specific timestamps. This would also make it easy to then drop function create_stressdata_masterdata_file_paths
- There is NaNs in the data. I do not know how they are dealt with later, but it might make sense to put some added effort into tidying this in the saved files
- later in the scripts some trimming/overwriting of net_profit margins happens to the dataset. Let us please discuss if we assume this will be a permanent solution (--> add it in prewrangling), or if that is subject to change (--> move steps to a function)

