### PR TITLE
hot fix: explicitly filter out etp2017 - power sector comboination fr…

### DIFF
--- a/web_tool_stress_test.R
+++ b/web_tool_stress_test.R
@@ -294,6 +294,7 @@ if (file.exists(file.path(results_path, pf_name, paste0("Equity_results_", calcu
   )
 
   pacta_equity_results_full <- pacta_equity_results_full %>%
+    filter(!(scenario == "ETP2017_NPS" & ald_sector == "Power")) %>%
     filter(scenario %in% scenarios) %>%
     mutate(scenario = ifelse(str_detect(scenario, "_"), str_extract(scenario, "[^_]*$"), scenario)) %>%
     check_portfolio_consistency()
@@ -493,6 +494,7 @@ if (file.exists(file.path(results_path, pf_name, paste0("Bonds_results_", calcul
   )
 
   pacta_bonds_results_full <- pacta_bonds_results_full %>%
+    filter(!(scenario == "ETP2017_NPS" & ald_sector == "Power")) %>%
     filter(scenario %in% scenarios) %>%
     mutate(scenario = ifelse(str_detect(scenario, "_"), str_extract(scenario, "[^_]*$"), scenario)) %>%
     check_portfolio_consistency()


### PR DESCRIPTION
…om pacta data

closes ADO 1868 https://dev.azure.com/2DegreesInvesting/2DegreesInvesting/_workitems/edit/1868

This PR
- makes a hotfix that removes the combination of pacta resultswith scenario source ETP2017 and ald_sector power in the web script 
- keeping this combination will introduce duplicates, as the code cannot distinguish it from the WEO2019 power sector
- it seems like in the past this was not a problem, because that combination of data was not passed