### PR TITLE
use testing project per default

### DIFF
--- a/st_project_settings.yml
+++ b/st_project_settings.yml
@@ -1,6 +1,6 @@
 default:
 
-  project_name: TRISK
+  project_name: ST_TESTING
 
   project_internal:
     twodii_internal: TRUE


### PR DESCRIPTION
This closes ADO_1818
Project ST_TESTING was set up based on TRISK project, but all data that is not necessary for the (currently only) supported ec_cb workflow was removed to facilitate getting an overview.