### PR TITLE
1540 lr read wrangle pacta results

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -801,26 +801,49 @@ ground truth. It is recommended though to set the parameters in line with at
 least imaginably realistic values based on the literature and/or worst case
 settings in case this is used for stress testing.
 
-**company_emissions_data_input:** A csv file with the following columns
-(sources or comments):
+**company_emissions_data_input:** For each asset type, an rda file with the
+following columns:
 
-- "company_id" (not required)
-- "company_name"
-- "actual_emissions" (not required)
-- "scenario"
-- "allowed_emission" (not required)
-- "avg_ef"
-- "allowed_production"
-- "current_production"
-- "revenue" (not required)
-- "unit_revenue" (not required)
-- "unit_emissions"
-- "ebit" (not required)
+- investor_name = "c"
+- portfolio_name = "c"
+- company_name = "c"
+- id = "c"/"d" (depending on asset type)
+- scenario = "c"
+- allocation = "c"
+- asset_type = "c"
+- scenario_geography = "c"
+- equity_market = "c"
+- year = "d"
+- financial_sector = "c"
+- ald_sector = "c"
+- technology = "c"
+- plan_tech_prod = "d"
+- plan_emission_factor = "d"
+- scen_tech_prod = "d"
+- scen_emission_factor = "d"
+- plan_carsten = "d"
 
-... of type "dcdcdddddccd". This table is sourced from PACTA and gives us the
-production forecasts per company, as well as the allowed production trajectories
-for each scenario per company. Together with the average emissions intensity
-factors, we deduce the emissions overshoot based on this.
+These files are sourced from PACTA projects and correspond to company level
+PACTA result files (for P4I). They gives us the production forecasts per company,
+as well as the allowed production trajectories for each scenario per company.
+Together with the planned average emission factors and the allowed emission
+factors by scenario, we deduce the emissions overshoot based on this. We also
+get the exposure of the portfolio by company and technology from this file.
+
+**sector_eposures:** The sectorial exposures of the portfolio by asset type:
+
+- investor_name = "c"
+- portfolio_name = "c"
+- company_name = "c"
+- asset_type = "c"
+- financial_sector = "c"
+- valid_input = "l"
+- valid_value_usd = "d"
+- asset_value_usd = "d"
+- portfolio_value_usd = "d"
+
+This file is sourced from PACTA projects and corresponds to sector level
+portfolio overview files, based on the processed inputs of a P4I project.
 
 **company_ebit_data_input:** A csv file with the following columns:
 

--- a/README.md
+++ b/README.md
@@ -896,27 +896,52 @@ recommended though to set the parameters in line with at least
 imaginably realistic values based on the literature and/or worst case
 settings in case this is used for stress testing.
 
-**company\_emissions\_data\_input:** A csv file with the following
-columns (sources or comments):
+**company\_emissions\_data\_input:** For each asset type, an rda file
+with the following columns:
 
-  - “company\_id” (not required)
-  - “company\_name”
-  - “actual\_emissions” (not required)
-  - “scenario”
-  - “allowed\_emission” (not required)
-  - “avg\_ef”
-  - “allowed\_production”
-  - “current\_production”
-  - “revenue” (not required)
-  - “unit\_revenue” (not required)
-  - “unit\_emissions”
-  - “ebit” (not required)
+  - investor\_name = “c”
+  - portfolio\_name = “c”
+  - company\_name = “c”
+  - id = “c”/“d” (depending on asset type)
+  - scenario = “c”
+  - allocation = “c”
+  - asset\_type = “c”
+  - scenario\_geography = “c”
+  - equity\_market = “c”
+  - year = “d”
+  - financial\_sector = “c”
+  - ald\_sector = “c”
+  - technology = “c”
+  - plan\_tech\_prod = “d”
+  - plan\_emission\_factor = “d”
+  - scen\_tech\_prod = “d”
+  - scen\_emission\_factor = “d”
+  - plan\_carsten = “d”
 
-… of type “dcdcdddddccd”. This table is sourced from PACTA and gives us
-the production forecasts per company, as well as the allowed production
-trajectories for each scenario per company. Together with the average
-emissions intensity factors, we deduce the emissions overshoot based on
-this.
+These files are sourced from PACTA projects and correspond to company
+level PACTA result files (for P4I). They gives us the production
+forecasts per company, as well as the allowed production trajectories
+for each scenario per company. Together with the planned average
+emission factors and the allowed emission factors by scenario, we deduce
+the emissions overshoot based on this. We also get the exposure of the
+portfolio by company and technology from this file.
+
+**sector\_eposures:** The sectorial exposures of the portfolio by asset
+type:
+
+  - investor\_name = “c”
+  - portfolio\_name = “c”
+  - company\_name = “c”
+  - asset\_type = “c”
+  - financial\_sector = “c”
+  - valid\_input = “l”
+  - valid\_value\_usd = “d”
+  - asset\_value\_usd = “d”
+  - portfolio\_value\_usd = “d”
+
+This file is sourced from PACTA projects and corresponds to sector level
+portfolio overview files, based on the processed inputs of a P4I
+project.
 
 **company\_ebit\_data\_input:** A csv file with the following columns:
 

--- a/params_litigation_risk.yml
+++ b/params_litigation_risk.yml
@@ -13,6 +13,8 @@ default:
       - Oil&Gas
       - Coal
       - Automotive
+      - Steel
+      - Cement
 
   lists:
     scenario_geography_list:
@@ -49,3 +51,4 @@ default:
     net_profit_margin: 0.1
     backwards_years: 10
     reset_post_settlement: start
+    flat_multiplier: 0.15

--- a/stress_test_litigation_risk.R
+++ b/stress_test_litigation_risk.R
@@ -353,12 +353,14 @@ company_data_overshoot <- company_data %>%
     allowed_emission_b2ds = dplyr::if_else(.data$scenario == "B2DS", allowed_production * avg_ef, 0),
     allowed_emission_sds = dplyr::if_else(.data$scenario == "SDS", allowed_production * avg_ef, 0),
     allowed_emission_nps = dplyr::if_else(.data$scenario == "NPS", allowed_production * avg_ef, 0),
-    allowed_emission_cps = dplyr::if_else(.data$scenario == "CPS", allowed_production * avg_ef, 0),
+    allowed_emission_cps = dplyr::if_else(.data$scenario == "CPS", allowed_production * avg_ef, 0)
+  ) %>%
+  mutate(
     overshoot_actual = actual_emissions - allowed_emission,
-    overshoot_actual_b2ds = dplyr::if_else(.data$scenario == "B2DS", actual_emissions - allowed_emission_sds, 0),
+    overshoot_actual_b2ds = dplyr::if_else(.data$scenario == "B2DS", actual_emissions - allowed_emission_b2ds, 0),
     overshoot_actual_sds = dplyr::if_else(.data$scenario == "SDS", actual_emissions - allowed_emission_sds, 0),
-    overshoot_actual_nps = dplyr::if_else(.data$scenario == "NPS", actual_emissions - allowed_emission_sds, 0),
-    overshoot_actual_cps = dplyr::if_else(.data$scenario == "CPS", actual_emissions - allowed_emission_sds, 0)
+    overshoot_actual_nps = dplyr::if_else(.data$scenario == "NPS", actual_emissions - allowed_emission_nps, 0),
+    overshoot_actual_cps = dplyr::if_else(.data$scenario == "CPS", actual_emissions - allowed_emission_cps, 0)
   )
 
 # ADO 1540 - removed the cap for overshoot deltas
@@ -512,7 +514,7 @@ for (i in seq(1, nrow(scenario))) {
 }
 
 scc_results %>% write_csv(
-  file.path(project_location, "40_Results", "_litigation_risk_company_scc.csv")
+  file.path(project_location, "40_Results", "litigation_risk_company_scc.csv")
 )
 
 

--- a/stress_test_litigation_risk.R
+++ b/stress_test_litigation_risk.R
@@ -807,10 +807,6 @@ portfolio_liabilities <- company_results_npv %>%
     )
   )
 
-portfolio_liabilities <- portfolio_liabilities_eq %>%
-  dplyr::bind_rows(portfolio_liabilities_cb)
-
-
 
 portfolio_liabilities %>% write_csv(
   file.path(project_location, "40_Results", "litigation_risk_portfolio_impact.csv")

--- a/stress_test_litigation_risk.R
+++ b/stress_test_litigation_risk.R
@@ -79,9 +79,6 @@ investor_name_equity <- cfg_litigation_params$investor_name$investor_name_equity
 investor_name_bonds <- cfg_litigation_params$investor_name$investor_name_bonds
 flat_multiplier <- cfg_litigation_params$litigation$flat_multiplier
 
-# ADO 1540 - set reference scenario for SCC
-target_scenario_SCC <- "sds"
-
 ############################################################################
 ##### Filters---------------------------------------------------------------
 ############################################################################
@@ -751,7 +748,6 @@ company_results_npv %>% write_csv(
 
 
 technology_share_comp <- company_emissions_data_input %>%
-  # dplyr::filter(scenario == toupper(.env$target_scenario_SCC)) %>%
   dplyr::select(
     .data$investor_name, .data$portfolio_name, .data$company_name, .data$id,
     .data$asset_type, .data$scenario,

--- a/stress_test_litigation_risk.R
+++ b/stress_test_litigation_risk.R
@@ -789,11 +789,13 @@ technology_exposure <- technology_share_comp %>%
 # TODO: merge portfolio comp-tech exposures with company results (percentage loss)
 # TODO: same for SCC 20 and 40??
 portfolio_liabilities <- company_results_npv %>%
-  left_join(
+  dplyr::inner_join(
     technology_exposure,
     by = c("company_name", "asset_type", "scenario", "sector" = "ald_sector")
-  ) %>%
-  mutate(
+  )
+
+portfolio_liabilities <- portfolio_liabilities %>%
+  dplyr::mutate(
     value_change = dplyr::if_else(
       .data$asset_type == "Bonds",
       .data$company_tech_exposure * .data$percentage_value_change * .env$flat_multiplier,

--- a/stress_test_litigation_risk.R
+++ b/stress_test_litigation_risk.R
@@ -873,7 +873,9 @@ viz_company_results <- company_results %>%
   dplyr::group_by(.data$company_name) %>%
   dplyr::mutate(max_liability_perc = max(.data$liability_perc_ebit, na.rm = TRUE)) %>%
   dplyr::ungroup() %>%
-  dplyr::mutate(company_name = forcats::fct_reorder(.data$company_name, desc(max_liability_perc)))
+  dplyr::mutate(company_name = forcats::fct_reorder(.data$company_name, desc(max_liability_perc))) %>%
+  dplyr::filter(.data$company_name %in% unique(.env$technology_exposure$company_name)) %>%
+  dplyr::filter(.data$scenario == "SDS" | .data$scenario_name == "HER_CDD_TMS")
 
 comp_graph <- viz_company_results %>%
   ggplot(
@@ -913,6 +915,7 @@ subset_companies <- c(
   "Glencore Plc",
   "Canadian Natural Resources Ltd"
 )
+subset_companies <- unique(technology_exposure$company_name)
 
 subset_models <- c(
   "CDD_TMS",
@@ -922,13 +925,17 @@ subset_models <- c(
 
 viz_company_results_subset <- viz_company_results %>%
   dplyr::filter(
-    company_name %in% subset_companies &
-      scenario_name %in% subset_models
+    .data$company_name %in% .env$subset_companies &
+      .data$scenario_name %in% .env$subset_models
   ) %>%
   dplyr::group_by(.data$company_name) %>%
   dplyr::mutate(max_liability_perc = max(.data$liability_perc_ebit, na.rm = TRUE)) %>%
   dplyr::ungroup() %>%
-  dplyr::mutate(company_name = forcats::fct_reorder(.data$company_name, desc(max_liability_perc)))
+  dplyr::mutate(
+    company_name = forcats::fct_reorder(
+      .data$company_name, dplyr::desc(.data$max_liability_perc)
+    )
+  )
 
 comp_graph_subset <- viz_company_results_subset %>%
   ggplot(
@@ -951,7 +958,11 @@ viz_company_results_payout_subset <- viz_company_results_subset %>%
   dplyr::group_by(.data$company_name) %>%
   dplyr::mutate(max_liability = max(.data$liability_total, na.rm = TRUE)) %>%
   dplyr::ungroup() %>%
-  dplyr::mutate(company_name = forcats::fct_reorder(.data$company_name, desc(max_liability)))
+  dplyr::mutate(
+    company_name = forcats::fct_reorder(
+      .data$company_name, dplyr::desc(.data$max_liability)
+    )
+  )
 
 
 comp_graph_payout_subset <- viz_company_results_payout_subset %>%

--- a/stress_test_litigation_risk.R
+++ b/stress_test_litigation_risk.R
@@ -873,7 +873,11 @@ viz_company_results <- company_results %>%
   dplyr::group_by(.data$company_name) %>%
   dplyr::mutate(max_liability_perc = max(.data$liability_perc_ebit, na.rm = TRUE)) %>%
   dplyr::ungroup() %>%
-  dplyr::mutate(company_name = forcats::fct_reorder(.data$company_name, desc(max_liability_perc))) %>%
+  dplyr::mutate(
+    company_name = forcats::fct_reorder(
+      .data$company_name, dplyr::desc(.data$max_liability_perc)
+    )
+  ) %>%
   dplyr::filter(.data$company_name %in% unique(.env$technology_exposure$company_name)) %>%
   dplyr::filter(.data$scenario == "SDS" | .data$scenario_name == "HER_CDD_TMS")
 

--- a/stress_test_litigation_risk.R
+++ b/stress_test_litigation_risk.R
@@ -751,10 +751,10 @@ company_results_npv %>% write_csv(
 
 
 technology_share_comp <- company_emissions_data_input %>%
-  dplyr::filter(scenario == toupper(.env$target_scenario_SCC)) %>%
+  # dplyr::filter(scenario == toupper(.env$target_scenario_SCC)) %>%
   dplyr::select(
     .data$investor_name, .data$portfolio_name, .data$company_name, .data$id,
-    .data$asset_type,
+    .data$asset_type, .data$scenario,
     .data$scenario_geography, .data$ald_sector, #.data$technology,
     .data$plan_carsten
   )
@@ -791,7 +791,7 @@ technology_exposure <- technology_share_comp %>%
 portfolio_liabilities <- company_results_npv %>%
   left_join(
     technology_exposure,
-    by = c("company_name", "asset_type", "sector" = "ald_sector")
+    by = c("company_name", "asset_type", "scenario", "sector" = "ald_sector")
   ) %>%
   mutate(
     value_change = dplyr::if_else(


### PR DESCRIPTION
closes ADO 1540, 1542, 1543
https://dev.azure.com/2DegreesInvesting/2DegreesInvesting/_workitems/edit/1540
https://dev.azure.com/2DegreesInvesting/2DegreesInvesting/_workitems/edit/1542
https://dev.azure.com/2DegreesInvesting/2DegreesInvesting/_workitems/edit/1543

This PR:
- reads in the remaining required company/emissions/portfolio files that can be derived from PACTA from a P4I PACTA project
- reads the ebit/financial data from input files derived from financial data bases
- it updates the README to explain how the user needs to set up the configuration in order to get the required data sets
- it cleans the code so that proper namespacing  and data masking is used where appropriate
- it refactors the data sets in the workflow to reduce complexity
- it always returns SCC results for all available scenarios instead of one select scenario
- it can process Equity and Bonds portfolios simulataneously
- it assumes shocks on corporate bonds must use a 15% flat multiplier when based on the DCF calculation (could be extended to credit risk module in the future)
- allows for all pacta sectors to be processed

Note:
- Some questions remain with regard to methodology and data.
- These are addressed in the following task: https://dev.azure.com/2DegreesInvesting/2DegreesInvesting/_workitems/edit/1545