### PR TITLE
add credit risk module to eq workflow

### DIFF
--- a/QA_scripts/change_check_eq.R
+++ b/QA_scripts/change_check_eq.R
@@ -6,10 +6,17 @@ import_asset_results <- function(project_name, investor_name) {
 
   equity_results_company <- readr::read_csv(file.path(results_path, investor_name, "stress_test_results_equity_comp.csv"))
   equity_results_port <- readr::read_csv(file.path(results_path, investor_name, "stress_test_results_equity_port.csv"))
+  equity_expected_loss <- readr::read_csv(file.path(results_path, paste0("stress_test_results_eq_comp_el_", project_name, ".csv")))
+  equity_annual_pd_changes_sector <- readr::read_csv(file.path(results_path, paste0("stress_test_results_eq_sector_pd_changes_annual.csv")))
+  equity_overall_pd_changes_sector <- readr::read_csv(file.path(results_path, paste0("stress_test_results_eq_sector_pd_changes_overall.csv")))
+
 
   asset_results <- list(
     equity_results_company = equity_results_company,
-    equity_results_port = equity_results_port
+    equity_results_port = equity_results_port,
+    equity_expected_loss = equity_expected_loss,
+    equity_annual_pd_changes_sector = equity_annual_pd_changes_sector,
+    equity_overall_pd_changes_sector = equity_overall_pd_changes_sector
   )
 
   return(asset_results)
@@ -46,6 +53,8 @@ check_all_equal <- function(old_results, new_results) {
 ## It makes sense to use whenever you expect all or some results to be unchanged
 ## by a release as it checks for equality of old and new data.
 ## If not you will have to change the expectations to use it.
+
+### 0. set a seed at the top of stress_test_model_eq.R
 
 ### 1. check out master branch of repo (or whichever branch you want to use as reference)
 source("stress_test_model_eq.R") # calculates results with checked out branch

--- a/stress_test_model_cb.R
+++ b/stress_test_model_cb.R
@@ -401,7 +401,7 @@ for (i in seq(1, nrow(transition_scenarios))) {
   # TODO: ADO 879 - note which companies are removed here, due to mismatch
 
   bonds_annual_profits <- bonds_annual_profits %>%
-    arrange(
+    dplyr::arrange(
       scenario_name, investor_name, portfolio_name, scenario_geography, id,
       company_name, ald_sector, technology, year
     ) %>%

--- a/stress_test_model_eq.R
+++ b/stress_test_model_eq.R
@@ -135,6 +135,9 @@ discount_rate <- cfg_mod$financials$discount_rate # Discount rate
 ##### OPEN: this needs to be estimated based on data
 terminal_value <- cfg_mod$financials$terminal_value
 div_netprofit_prop_coef <- cfg_mod$financials$div_netprofit_prop_coef # determine this value using bloomberg data
+risk_free_rate <- cfg_mod$financials$risk_free_rate
+lgd_senior_claims <- cfg_mod$financials$lgd_senior_claims
+lgd_subordinated_claims <- cfg_mod$financials$lgd_subordinated_claims
 
 ###########################################################################
 # Load input datasets------------------------------------------------------
@@ -165,7 +168,12 @@ pacta_equity_results <- read_pacta_results(
     scenario_geography_filter = scenario_geography_filter,
     scenarios_filter = scenarios_filter,
     equity_market_filter = cfg$Lists$Equity.Market.List
-  )
+  ) %>%
+  dplyr::group_by(company_name) %>%
+  mutate(
+    term = round(runif(n = 1, min = 1, max = 10), 0) # TODO: temporary addition, needs to come directly from input
+  ) %>%
+  ungroup()
 
 # Load sector exposures of portfolio------------------------
 sector_exposures <- readRDS(file.path(proc_input_path, "overview_portfolio.rda")) %>%
@@ -229,10 +237,10 @@ scenario_data <- scenario_data %>%
 
 # Load price data----------------------------------------
 df_price <- read_price_data(
-    path = file.path(data_location, paste0("prices_data_", price_data_version, ".csv")),
-    version = "old",
-    expected_technologies = technologies_lookup
-  ) %>%
+  path = file.path(data_location, paste0("prices_data_", price_data_version, ".csv")),
+  version = "old",
+  expected_technologies = technologies_lookup
+) %>%
   filter(year >= start_year) %>%
   check_price_consistency()
 
@@ -306,17 +314,19 @@ equity_port_aum <- calculate_aum(sector_exposures)
 # Calculation of results---------------------------------------------------
 ###########################################################################
 
-
 # Equity results  -------------------------------------------------------------
 
 equity_results <- c()
 qa_annual_profits_eq <- c()
+equity_expected_loss <- c()
+equity_annual_pd_changes <- c()
+qa_pd_changes <- c()
 
 for (i in seq(1, nrow(transition_scenarios))) {
   transition_scenario_i <- transition_scenarios[i, ]
+  overshoot_method <- transition_scenario_i$overshoot_method
   year_of_shock <- transition_scenario_i$year_of_shock
   duration_of_shock <- transition_scenario_i$duration_of_shock
-  overshoot_method <- transition_scenario_i$overshoot_method
   use_prod_forecasts_baseline <- transition_scenario_i$use_prod_forecasts_baseline
   use_prod_forecasts_ls <- transition_scenario_i$use_prod_forecasts_ls
 
@@ -334,7 +344,11 @@ for (i in seq(1, nrow(transition_scenarios))) {
     dplyr::group_by(ald_sector, technology) %>%
     #### OPEN: Potentially a problem with the LS price calculation. Concerning warning
     mutate(
-      late_sudden_price = late_sudden_prices(SDS_price = SDS_price, Baseline_price = Baseline_price, overshoot_method = overshoot_method)
+      late_sudden_price = late_sudden_prices(
+        SDS_price = SDS_price,
+        Baseline_price = Baseline_price,
+        overshoot_method = overshoot_method
+      )
     ) %>%
     ungroup()
 
@@ -422,12 +436,37 @@ for (i in seq(1, nrow(transition_scenarios))) {
       .data$scenario %in% .env$scenario_to_follow_ls
     )
 
+  financial_data_equity_pd <- financial_data_equity %>%
+    select(company_name, ald_sector, technology, pd)
+
+  report_duplicates(
+    data = financial_data_equity_pd,
+    cols = names(financial_data_equity_pd)
+  )
+
+  rows_plan_carsten <- nrow(plan_carsten_equity)
+
+  plan_carsten_equity <- plan_carsten_equity %>%
+    dplyr::inner_join(financial_data_equity_pd, by = c("company_name", "ald_sector", "technology"))
+
+  cat("number of rows dropped from technology_exposure by joining financial data
+      on company_name, ald_sector and technology = ",
+      rows_plan_carsten - nrow(plan_carsten_equity), "\n")
+  # TODO: ADO 879 - note which companies are removed here, due to mismatch
+
+  equity_annual_profits <- equity_annual_profits %>%
+    filter(!is.na(company_id))
+
   plan_carsten_equity <- plan_carsten_equity %>%
     select(
       investor_name, portfolio_name, company_name, ald_sector, technology,
-      scenario_geography, year, plan_carsten, plan_sec_carsten
-    ) %>%
-    distinct(across(everything()))
+      scenario_geography, year, plan_carsten, plan_sec_carsten, term, pd
+    )
+
+  report_duplicates(
+    data = plan_carsten_equity,
+    cols = names(plan_carsten_equity)
+  )
 
   if (!exists("excluded_companies")) {
     equity_results <- bind_rows(
@@ -443,6 +482,43 @@ for (i in seq(1, nrow(transition_scenarios))) {
         exclusion = NULL
       )
     )
+    equity_overall_pd_changes <- equity_annual_profits %>%
+      calculate_pd_change_overall(
+        shock_year = transition_scenario_i$year_of_shock,
+        end_of_analysis = end_year,
+        exclusion = NULL,
+        risk_free_interest_rate = risk_free_rate
+      )
+
+    # TODO: ADO 879 - note which companies produce missing results due to
+    # insufficient input information (e.g. NAs for financials or 0 equity value)
+
+    equity_expected_loss <- bind_rows(
+      equity_expected_loss,
+      company_expected_loss(
+        data = equity_overall_pd_changes,
+        loss_given_default = lgd_subordinated_claims, # TODO: which one?
+        exposure_at_default = plan_carsten_equity,
+        port_aum = equity_port_aum
+      )
+    )
+
+    # TODO: ADO 879 - note which companies produce missing results due to
+    # insufficient output from overall pd changes or related financial data inputs
+
+    equity_annual_pd_changes <- bind_rows(
+      equity_annual_pd_changes,
+      calculate_pd_change_annual(
+        data = equity_annual_profits,
+        shock_year = transition_scenario_i$year_of_shock,
+        end_of_analysis = end_year,
+        exclusion = NULL,
+        risk_free_interest_rate = risk_free_rate
+      )
+    )
+    # TODO: ADO 879 - note which companies produce missing results due to
+    # insufficient input information (e.g. NAs for financials or 0 equity value)
+
   } else {
     equity_results <- bind_rows(
       equity_results,
@@ -457,6 +533,35 @@ for (i in seq(1, nrow(transition_scenarios))) {
         exclusion = excluded_companies
       )
     )
+
+    equity_overall_pd_changes <- equity_annual_profits %>%
+      calculate_pd_change_overall(
+        shock_year = transition_scenario_i$year_of_shock,
+        end_of_analysis = end_year,
+        exclusion = excluded_companies,
+        risk_free_interest_rate = risk_free_rate
+      )
+
+    equity_expected_loss <- bind_rows(
+      equity_expected_loss,
+      company_expected_loss(
+        data = equity_overall_pd_changes,
+        loss_given_default = lgd_subordinated_claims, # TODO: which one?
+        exposure_at_default = plan_carsten_equity,
+        port_aum = equity_port_aum
+      )
+    )
+
+    equity_annual_pd_changes <- bind_rows(
+      equity_annual_pd_changes,
+      calculate_pd_change_annual(
+        data = equity_annual_profits,
+        shock_year = transition_scenario_i$year_of_shock,
+        end_of_analysis = end_year,
+        exclusion = excluded_companies,
+        risk_free_interest_rate = risk_free_rate
+      )
+    )
   }
 }
 
@@ -468,3 +573,69 @@ equity_results %>% write_results(
   level = calculation_level,
   file_type = "csv"
 )
+
+# Output equity credit risk results
+equity_expected_loss <- equity_expected_loss %>%
+  dplyr::select(
+    scenario_name, scenario_geography, investor_name, portfolio_name,
+    company_name, id, ald_sector, technology, equity_0_baseline,
+    equity_0_late_sudden, debt, volatility, risk_free_rate, term,
+    Survival_baseline, Survival_late_sudden, PD_baseline, PD_late_sudden,
+    PD_change, pd, lgd, percent_exposure, exposure_at_default,
+    expected_loss_baseline, expected_loss_late_sudden
+  ) %>%
+  dplyr::arrange(
+    scenario_geography, scenario_name, investor_name, portfolio_name,
+    company_name, ald_sector, technology
+  )
+
+equity_expected_loss %>%
+  readr::write_csv(file.path(
+    results_path,
+    paste0("stress_test_results_eq_comp_el_", project_name, ".csv")
+  ))
+
+# TODO: this is an unweighted average so far. keep in mind.
+equity_annual_pd_changes_sector <- equity_annual_pd_changes %>%
+  dplyr::group_by(
+    scenario_name, scenario_geography, investor_name, portfolio_name,
+    ald_sector, technology, year
+  ) %>%
+  dplyr::summarise(
+    PD_change_late_sudden = mean((PD_late_sudden - PD_baseline), na.rm = TRUE),
+    .groups = "drop"
+  ) %>%
+  dplyr::ungroup() %>%
+  dplyr::arrange(
+    scenario_geography, scenario_name, investor_name, portfolio_name,
+    ald_sector, technology, year
+  )
+
+equity_annual_pd_changes_sector %>%
+  readr::write_csv(file.path(
+    results_path,
+    paste0("stress_test_results_eq_sector_pd_changes_annual.csv")
+  ))
+
+# TODO: this is an unweighted average so far. keep in mind.
+equity_overall_pd_changes_sector <- equity_expected_loss %>%
+  dplyr::group_by(
+    scenario_name, scenario_geography, investor_name, portfolio_name,
+    ald_sector, technology, term
+  ) %>%
+  dplyr::summarise(
+    PD_change_late_sudden = mean((PD_late_sudden - PD_baseline), na.rm = TRUE),
+    .groups = "drop"
+  ) %>%
+  dplyr::ungroup() %>%
+  dplyr::arrange(
+    scenario_geography, scenario_name, investor_name, portfolio_name,
+    ald_sector, technology, term
+  )
+
+equity_overall_pd_changes_sector %>%
+  readr::write_csv(file.path(
+    results_path,
+    paste0("stress_test_results_eq_sector_pd_changes_overall.csv")
+  ))
+

--- a/stress_test_model_eq.R
+++ b/stress_test_model_eq.R
@@ -170,10 +170,10 @@ pacta_equity_results <- read_pacta_results(
     equity_market_filter = cfg$Lists$Equity.Market.List
   ) %>%
   dplyr::group_by(company_name) %>%
-  mutate(
+  dplyr::mutate(
     term = round(runif(n = 1, min = 1, max = 10), 0) # TODO: temporary addition, needs to come directly from input
   ) %>%
-  ungroup()
+  dplyr::ungroup()
 
 # Load sector exposures of portfolio------------------------
 sector_exposures <- readRDS(file.path(proc_input_path, "overview_portfolio.rda")) %>%
@@ -215,7 +215,7 @@ if(twodii_internal == TRUE | start_year < 2020) {
       direction = Direction,
       fair_share_perc = FairSharePerc
     ) %>%
-    mutate(scenario = stringr::str_replace(scenario, "NPSRTS", "NPS"))
+    dplyr::mutate(scenario = stringr::str_replace(scenario, "NPSRTS", "NPS"))
 } else {
   scenario_data <- readr::read_csv(scen_data_file, col_types = "ccccccncn") %>%
     dplyr::rename(source = scenario_source)
@@ -402,7 +402,7 @@ for (i in seq(1, nrow(transition_scenarios))) {
   # TODO: ADO 879 - note which companies are removed here, due to mismatch
 
   equity_annual_profits <- equity_annual_profits %>%
-    arrange(
+    dplyr::arrange(
       scenario_name, investor_name, portfolio_name, scenario_geography, id,
       company_name, ald_sector, technology, year
     ) %>%
@@ -437,7 +437,7 @@ for (i in seq(1, nrow(transition_scenarios))) {
     )
 
   financial_data_equity_pd <- financial_data_equity %>%
-    select(company_name, ald_sector, technology, pd)
+    dplyr::select(company_name, ald_sector, technology, pd)
 
   report_duplicates(
     data = financial_data_equity_pd,
@@ -455,7 +455,7 @@ for (i in seq(1, nrow(transition_scenarios))) {
   # TODO: ADO 879 - note which companies are removed here, due to mismatch
 
   equity_annual_profits <- equity_annual_profits %>%
-    filter(!is.na(company_id))
+    dplyr::filter(!is.na(company_id))
 
   plan_carsten_equity <- plan_carsten_equity %>%
     dplyr::select(
@@ -493,7 +493,7 @@ for (i in seq(1, nrow(transition_scenarios))) {
     # TODO: ADO 879 - note which companies produce missing results due to
     # insufficient input information (e.g. NAs for financials or 0 equity value)
 
-    equity_expected_loss <- bind_rows(
+    equity_expected_loss <- dplyr::bind_rows(
       equity_expected_loss,
       company_expected_loss(
         data = equity_overall_pd_changes,
@@ -506,7 +506,7 @@ for (i in seq(1, nrow(transition_scenarios))) {
     # TODO: ADO 879 - note which companies produce missing results due to
     # insufficient output from overall pd changes or related financial data inputs
 
-    equity_annual_pd_changes <- bind_rows(
+    equity_annual_pd_changes <- dplyr::bind_rows(
       equity_annual_pd_changes,
       calculate_pd_change_annual(
         data = equity_annual_profits,
@@ -542,7 +542,7 @@ for (i in seq(1, nrow(transition_scenarios))) {
         risk_free_interest_rate = risk_free_rate
       )
 
-    equity_expected_loss <- bind_rows(
+    equity_expected_loss <- dplyr::bind_rows(
       equity_expected_loss,
       company_expected_loss(
         data = equity_overall_pd_changes,
@@ -552,7 +552,7 @@ for (i in seq(1, nrow(transition_scenarios))) {
       )
     )
 
-    equity_annual_pd_changes <- bind_rows(
+    equity_annual_pd_changes <- dplyr::bind_rows(
       equity_annual_pd_changes,
       calculate_pd_change_annual(
         data = equity_annual_profits,
@@ -566,7 +566,7 @@ for (i in seq(1, nrow(transition_scenarios))) {
 }
 
 # Output equity results
-equity_results %>% write_results(
+equity_results %>% readr::write_results(
   path_to_results = results_path,
   investorname = investor_name_placeholder,
   asset_type = "equity",

--- a/stress_test_model_eq.R
+++ b/stress_test_model_eq.R
@@ -566,7 +566,7 @@ for (i in seq(1, nrow(transition_scenarios))) {
 }
 
 # Output equity results
-equity_results %>% readr::write_results(
+equity_results %>% write_results(
   path_to_results = results_path,
   investorname = investor_name_placeholder,
   asset_type = "equity",


### PR DESCRIPTION
closes ADO 2182 (coding part of 2126): https://dev.azure.com/2DegreesInvesting/2DegreesInvesting/_workitems/edit/2182 

This PR:
- adds the credit risk model section of the code to the equity workflow
- adapts joins where required
- loads required additional inputs and initialises corresponding objects
- writes the CR results to the result folder according to the common pattern