### PR TITLE
use overall pd calculation, not expected losses to write overall pd file

### DIFF
--- a/R/main_stress_test_bonds.R
+++ b/R/main_stress_test_bonds.R
@@ -211,6 +211,7 @@ run_stress_test_bonds <- function(lgd_senior_claims = 0.45,
     results = results,
     expected_loss = expected_loss,
     annual_pd_changes = annual_pd_changes,
+    overall_pd_changes = overall_pd_changes,
     asset_type = asset_type,
     calculation_level = calculation_level
   )

--- a/R/main_stress_test_equity.R
+++ b/R/main_stress_test_equity.R
@@ -210,6 +210,7 @@ run_stress_test_equity <- function(lgd_senior_claims = 0.45,
     results = results,
     expected_loss = expected_loss,
     annual_pd_changes = annual_pd_changes,
+    overall_pd_changes = overall_pd_changes,
     asset_type = asset_type,
     calculation_level = calculation_level
   )

--- a/R/main_stress_test_loans.R
+++ b/R/main_stress_test_loans.R
@@ -218,6 +218,7 @@ run_stress_test_loans <- function(lgd_senior_claims = 0.45,
     results = results,
     expected_loss = expected_loss,
     annual_pd_changes = annual_pd_changes,
+    overall_pd_changes = overall_pd_changes,
     asset_type = asset_type,
     calculation_level = calculation_level
   )

--- a/R/write_results.R
+++ b/R/write_results.R
@@ -6,13 +6,15 @@
 #' @param expected_loss Tibble holding stress test results on expected loss.
 #' @param annual_pd_changes Tibble holding stress test results on annual changes
 #'   of probability of default.
+#' @param overall_pd_changes Tibble holding stress test results on overall changes
+#'   of probability of default.
 #' @param asset_type String holding asset type.
 #' @param calculation_level String holding calculation level.
 #'
 #' @return NULL
 write_stress_test_results <- function(results, expected_loss,
-                                      annual_pd_changes, asset_type,
-                                      calculation_level) {
+                                      annual_pd_changes, overall_pd_changes,
+                                      asset_type, calculation_level) {
 
   results_path <- file.path(get_st_data_path("ST_PROJECT_FOLDER"), "outputs")
 
@@ -76,7 +78,7 @@ write_stress_test_results <- function(results, expected_loss,
       paste0("stress_test_results_", asset_type, "_sector_pd_changes_annual.csv")
     ))
 
-  overall_pd_changes_sector <- expected_loss %>%
+  overall_pd_changes_sector <- overall_pd_changes %>%
     dplyr::group_by(
       .data$scenario_name, .data$scenario_geography, .data$investor_name,
       .data$portfolio_name, .data$ald_sector, .data$term

--- a/man/write_stress_test_results.Rd
+++ b/man/write_stress_test_results.Rd
@@ -8,6 +8,7 @@ write_stress_test_results(
   results,
   expected_loss,
   annual_pd_changes,
+  overall_pd_changes,
   asset_type,
   calculation_level
 )
@@ -18,6 +19,9 @@ write_stress_test_results(
 \item{expected_loss}{Tibble holding stress test results on expected loss.}
 
 \item{annual_pd_changes}{Tibble holding stress test results on annual changes
+of probability of default.}
+
+\item{overall_pd_changes}{Tibble holding stress test results on overall changes
 of probability of default.}
 
 \item{asset_type}{String holding asset type.}


### PR DESCRIPTION
closes ADO 2432: https://dev.azure.com/2DegreesInvesting/2DegreesInvesting/_workitems/edit/2432

This PR:
- uses the overall PD calculation tibble to write sector level overall pd results instead of using the expected loss tibble for that
- using the expected loss tibble is not possible anymore, because it is inner_joined on the term input, thus removing the overall PDs for all other maturities
- change checks passed for all result types except for overall pd changes. This is expected, as we now keep all maturities. The content of the remaining rows that were in the old results as well are identical though, which is a sign that his is behaving as expected