### PR TITLE
EXPERIMENTAL test if CI works with sessionInfo v1.1.1

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -45,6 +45,7 @@ jobs:
 
       - name: Install older sessionInfo
         run: |
+          install.packages("devtools")
           devtools::install_version("sessionInfo", "1.1.1")
         shell: Rscript {0}
 

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -43,6 +43,11 @@ jobs:
         with:
           extra-packages: rcmdcheck
 
+      - name: Install older sessionInfo
+        run: |
+          devtools::install_version("sessionInfo", "1.1.1")
+        shell: Rscript {0}
+
       - uses: r-lib/actions/check-r-package@v1
 
       - name: Show testthat output


### PR DESCRIPTION
This is an experiment to try confirm the issue why CI is failing is the recent (Oct 31st) release of sessionInfo.