### PR TITLE
Address R CMD warnings and notes

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -24,3 +24,4 @@
 ^wip_data_qa\.R$
 ^\.github$
 ^\.Renviron$
+^vignettes/articles$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,7 +23,7 @@ License: file LICENSE
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.1
+RoxygenNote: 7.1.2
 Imports: 
     config,
     dplyr,

--- a/R/calc_survival_probability_merton.R
+++ b/R/calc_survival_probability_merton.R
@@ -2,8 +2,8 @@
 #'
 #' Function calculates survival probability for a maturity based on a structural
 #' Merton model.
-#' For details on implementation please compare [CreditRisk::Merton()].
-#' Unlike [CreditRisk::Merton()] this implementation:
+#' For details on implementation please compare `CreditRisk::Merton()`.
+#' Unlike `CreditRisk::Merton()` this implementation:
 #' 1. only holds functionality to calculate probability of survival
 #' 1. can be called in vectorised fashion
 #' 1. additionally checks that all input values are of the same length

--- a/R/imports.R
+++ b/R/imports.R
@@ -46,6 +46,7 @@ globalVariables(
     "net_profit_margin",
     "pacta_sectors_not_analysed",
     "pd",
+    "plan_carsten",
     "plan_sec_carsten",
     "portfolio_name",
     "profit_margin_preferred",

--- a/man/calc_survival_probability_merton.Rd
+++ b/man/calc_survival_probability_merton.Rd
@@ -23,8 +23,8 @@ A vector holding survival probabilities,
 \description{
 Function calculates survival probability for a maturity based on a structural
 Merton model.
-For details on implementation please compare \code{\link[CreditRisk:Merton]{CreditRisk::Merton()}}.
-Unlike \code{\link[CreditRisk:Merton]{CreditRisk::Merton()}} this implementation:
+For details on implementation please compare \code{CreditRisk::Merton()}.
+Unlike \code{CreditRisk::Merton()} this implementation:
 \enumerate{
 \item only holds functionality to calculate probability of survival
 \item can be called in vectorised fashion


### PR DESCRIPTION
This PR addresses a couple of warnings/notes I see on 
R CMD check. This leaves only one note of this type:

```
  set_project_parameters: no visible binding for '<<-' assignment to
    ‘inc_stresstest’
```
