### PR TITLE
Avoid warning about partial matching

### DIFF
--- a/tests/testthat/test-annual_pd_change_sector_shock_year.R
+++ b/tests/testthat/test-annual_pd_change_sector_shock_year.R
@@ -13,7 +13,7 @@ test_that("production trajectories function returns a ggplot object", {
 
   test_plot <- annual_pd_change_sector_shock_year(
     data = test_input_graph,
-    shock_year = test_shock_year,
+    shock_year_filter = test_shock_year,
     geography_filter = test_geography_filter
   )
 


### PR DESCRIPTION
   
`devtools::test()` used to yield this warning which is now fixed:
    

    Warning (test-annual_pd_change_sector_shock_year.R:14:3): production trajectories function returns a ggplot object
    partial argument match of 'shock_year' to 'shock_year_filter'

