### PR TITLE
Use .data$ to avoid NOTE: Undefined global variables

### DIFF
--- a/R/wrangle_and_check.R
+++ b/R/wrangle_and_check.R
@@ -29,7 +29,7 @@ wrangle_and_check_sector_exposures <- function(sector_exposures, asset_type) {
   if (any(sector_exposures$valid_value_usd < 0)) {
     affected_sectors <- sector_exposures %>%
       dplyr::filter(valid_value_usd < 0) %>%
-      dplyr::pull(financial_sector)
+      dplyr::pull(.data$financial_sector)
 
     stop(paste0("Asset under management has negative value in sector(s) ", paste0(affected_sectors, collapse = ", "), ".
                 This is not supported by the analysis."), call. = FALSE)


### PR DESCRIPTION
This PR avoids a NOTE we recently got rid of.

I could have added the variable to `globalVariables()` but I note the variable was introduced very recently, so maybe best to just tackle the underlying issue.

```
git log -S 'pull(financial_sector)'
 ...
Date:   Wed Nov 3 10:36:42 2021 +0100
```

I look forward to getting rid of all R CMD check issues so it's easier to notice when we inevitably introduce a new R CMD check issue

A painful reminder we still have many of these:

```
set_project_parameters: no visible binding for '<<-' assignment to
    ‘inc_stresstest’
```