### PR TITLE
Check pacta res

### DIFF
--- a/R/check_and_filter_data.R
+++ b/R/check_and_filter_data.R
@@ -88,5 +88,20 @@ check_and_filter_data <- function(st_data_list, start_year, end_year,
   },
   data_list, name_list)
 
+  has_negative_values <- pacta_results_filtered %>%
+    dplyr::select(plan_tech_prod, plan_carsten, scen_tech_prod, plan_sec_prod, plan_sec_carsten) %>%
+    purrr::map_lgl(function(col) {
+      any(col < 0)
+    })
+
+  if (any(has_negative_values)) {
+    stop(
+      paste0("Detected negative values on columns ",
+             paste0(names(has_negative_values[has_negative_values == TRUE]), collapse = ", "),
+             ". Analysis cannot process this."),
+      call. = FALSE
+    )
+  }
+
   return(data_list)
 }

--- a/R/check_and_filter_data.R
+++ b/R/check_and_filter_data.R
@@ -73,10 +73,20 @@ check_and_filter_data <- function(st_data_list, start_year, end_year,
     c("financial_sector", "investor_name", "portfolio_name")
   )
 
+  name_list <- list(
+    "capacity_factors_power", "excluded_companies", "df_price", "scenario_data",
+    "financial_data","pacta_results", "sector_exposures"
+    )
+
   mapply(function(data, cuc_cols) {
     report_all_duplicate_kinds(data = data, composite_unique_cols = cuc_cols)
   },
   data_list, cuc_list)
+
+  mapply(function(data, name_list) {
+    report_missings(data = data, name_data = name_list)
+  },
+  data_list, name_list)
 
   return(data_list)
 }

--- a/R/read_pacta_results.R
+++ b/R/read_pacta_results.R
@@ -21,7 +21,6 @@ read_pacta_results <- function(path = NULL,
   valid_input_file_path <- file.exists(file.path(path))
   stopifnot(valid_input_file_path)
 
-
   data <- readr::read_rds(path)
 
   expected_columns <- c(

--- a/R/wrangle_and_check.R
+++ b/R/wrangle_and_check.R
@@ -106,21 +106,6 @@ wrangle_and_check_pacta_results <- function(pacta_results, start_year, time_hori
     ) %>%
     dplyr::distinct_all()
 
-  has_negative_values <- wrangled_pacta_results %>%
-    dplyr::select(plan_tech_prod, plan_carsten, scen_tech_prod, plan_sec_prod, plan_sec_carsten) %>%
-    purrr::map_lgl(function(col) {
-      any(col < 0)
-    })
-
-  if (any(has_negative_values)) {
-    stop(
-      paste0("Detected negative values on columns ",
-             paste0(names(has_negative_values[has_negative_values == TRUE]), collapse = ", "),
-             ". Analysis cannot process this."),
-      call. = FALSE
-    )
-  }
-
   return(wrangled_pacta_results)
 }
 

--- a/R/wrangle_and_check.R
+++ b/R/wrangle_and_check.R
@@ -105,6 +105,23 @@ wrangle_and_check_pacta_results <- function(pacta_results, start_year, time_hori
       .data$equity_market == equity_market_filter
     ) %>%
     dplyr::distinct_all()
+
+  has_negative_values <- wrangled_pacta_results %>%
+    dplyr::select(plan_tech_prod, plan_carsten, scen_tech_prod, plan_sec_prod, plan_sec_carsten) %>%
+    purrr::map_lgl(function(col) {
+      any(col < 0)
+    })
+
+  if (any(has_negative_values)) {
+    stop(
+      paste0("Detected negative values on columns ",
+             paste0(names(has_negative_values[has_negative_values == TRUE]), collapse = ", "),
+             ". Analysis cannot process this."),
+      call. = FALSE
+    )
+  }
+
+  return(wrangled_pacta_results)
 }
 
 #' Wrangle financial data


### PR DESCRIPTION
This is not really a PR but a basis to talk about some potential problems i identified:

- i added reporting of missings for all inputs
- check that numeric cols in pacta results are >=0.

It showed:

- there is NAs on pricedata, but I assume on irrelavant cols
- for PACTA results for equity and loans there are NAs in pacta results, even after all the filtering. is this a problem?
- for PACTA results on loans there is no NAs in pacta results but 0. is this a problem, after all we still have the open bug Missings on VaR_company and company_value_change for bonds