### PR TITLE
use valid license

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,7 +16,7 @@ Description: The package provides functions and workflows for conducting
     stage and not finalised yet. Changes to the methodology will still be
     made that can and will impact the outcomes of the analysis.  For more
     information visit <https://2degrees-investing.org/>.
-License: file LICENSE
+License: MIT + file LICENSE
 Depends:
     R (> 3.5)
 Imports: 

--- a/LICENSE
+++ b/LICENSE
@@ -1,1 +1,2 @@
-Copyright 2021 2DII. All rights reserved.
+YEAR: 2021
+COPYRIGHT HOLDER: r2dii.climate.stress.test.authors


### PR DESCRIPTION
From the CRAN readiness blockers that  @maurolepore  identified I figured invalid license is the most relevant aspect to fix also before GH ready release. I based the license on https://github.com/2DegreesInvesting/r2dii.plot/blob/develop/LICENSE
This should be formally correct, since there was a more restrictive license before though I would also like to have @jacobvjk approval before merging.