### PR TITLE
rm non negative nad add raw total loan book size to overview

### DIFF
--- a/R/prep_and_calc_loan_book.R
+++ b/R/prep_and_calc_loan_book.R
@@ -103,6 +103,7 @@ run_prep_calculation_loans <- function(credit_type = "outstanding") {
   )
 
   #### Wrangle and prepare data-------------------------------------------------
+  # ADO 2690 - remove rows with negative loan values (not allowed in P4B)
   if (credit_type == "outstanding") {
     matched_non_negative <- matched %>%
       dplyr::filter(.data$loan_size_outstanding >= 0)
@@ -227,6 +228,7 @@ run_prep_calculation_loans <- function(credit_type = "outstanding") {
     dplyr::group_by(.data$investor_name, .data$portfolio_name, .data$asset_type, .data$valid_input) %>%
     dplyr::mutate(asset_value_usd = sum(.data$valid_value_usd, na.rm = TRUE)) %>%
     dplyr::ungroup() %>%
+    # ADO 2690 - set total loan book value using raw loan book
     dplyr::mutate(
       portfolio_value_usd = dplyr::if_else(
         credit_type == "outstanding",

--- a/R/prep_and_calc_loan_book.R
+++ b/R/prep_and_calc_loan_book.R
@@ -112,6 +112,17 @@ run_prep_calculation_loans <- function(credit_type = "outstanding") {
       dplyr::filter(.data$loan_size_credit_limit >= 0)
   }
 
+  if (nrow(matched_non_negative) < nrow(matched)) {
+    warning(
+      paste0(
+        nrow(matched) - nrow(matched_non_negative),
+        " loans removed from the matched loan book because of negative loan
+        values. Please check the input loan book to address this issue."
+      )
+      , call. = FALSE
+    )
+  }
+
   portfolio_size <- loanbook %>%
     # TODO: why distinct? Is there any way that id_loan is not unique?
     dplyr::distinct(


### PR DESCRIPTION
closes ADO 2690: https://dev.azure.com/2DegreesInvesting/2DegreesInvesting/_workitems/edit/2690

This PR:
- removes negative loans of the select loan type in the preparation script
- gets the raw total loan size for the total value of the `overview_portfolio` file
- change checks passed