### PR TITLE
2723 mismatch plan carsten

### DIFF
--- a/R/prep_and_calc_loan_book.R
+++ b/R/prep_and_calc_loan_book.R
@@ -144,8 +144,8 @@ run_prep_calculation_loans <- function(credit_type = "outstanding") {
     dplyr::mutate(
       portfolio_loan_size_outstanding = portfolio_size$portfolio_loan_size_outstanding,
       portfolio_loan_size_credit_limit = portfolio_size$portfolio_loan_size_credit_limit,
-      matched_portfolio_loan_size_outstanding = sum(.data$loan_size_outstanding, na.rm = TRUE),
-      matched_portfolio_loan_size_credit_limit = sum(.data$loan_size_credit_limit, na.rm = TRUE)
+      matched_portfolio_loan_size_outstanding = matched_portfolio_size$matched_portfolio_loan_size_outstanding,
+      matched_portfolio_loan_size_credit_limit = matched_portfolio_size$matched_portfolio_loan_size_credit_limit
     ) %>%
     dplyr::group_by(
       # ADO 1933 - we choose `name_ald` as this is an internal name that can be

--- a/R/prep_and_calc_loan_book.R
+++ b/R/prep_and_calc_loan_book.R
@@ -153,10 +153,13 @@ run_prep_calculation_loans <- function(credit_type = "outstanding") {
       .data$name_ald, .data$sector_ald, .data$loan_size_outstanding_currency,
       .data$loan_size_credit_limit_currency
     ) %>%
+    # ADO 2723 - loan shares calculated against matched loan book, not total loan book
+    # this is to ensure all scaling happens against the same denominator
+    # run_stress_test uses the matched portfolio to scale the overall impact
     dplyr::mutate(
-      comp_loan_share_outstanding = sum(.data$loan_size_outstanding, na.rm = TRUE) / .data$portfolio_loan_size_outstanding,
+      comp_loan_share_outstanding = sum(.data$loan_size_outstanding, na.rm = TRUE) / .data$matched_portfolio_loan_size_outstanding,
       comp_loan_size_outstanding = sum(.data$loan_size_outstanding, na.rm = TRUE),
-      comp_loan_share_credit_limit = sum(.data$loan_size_credit_limit, na.rm = TRUE) / .data$portfolio_loan_size_credit_limit,
+      comp_loan_share_credit_limit = sum(.data$loan_size_credit_limit, na.rm = TRUE) / .data$matched_portfolio_loan_size_credit_limit,
       comp_loan_size_credit_limit = sum(.data$loan_size_credit_limit, na.rm = TRUE)
     ) %>%
     dplyr::ungroup() %>%


### PR DESCRIPTION
closes ADO 2723: https://dev.azure.com/2DegreesInvesting/2DegreesInvesting/_workitems/edit/2723

This PR:
- ensures that the loan data prep calculates exposures with the same reference portfolio size as is later used to scale the company level impact back to the overall loan book.
- previously we erroneously used different denominators (raw loan book for getting loan exposure, matched loan book to rescale company shocks to loan book)
- the loan change check fails expectedly for all results that make use of the exposure. It does not fail for annual and overall pd changes. This is a good sign, since these two results are independent from portfolio exposures which means the calculation of risk on the company level remains unaffected.
- The sector exposures in the results of the new calculation match the sector level exposures in the matched loan book. Previously the result exposures were significantly smaller.