### PR TITLE
Fix 'false' must be a double vector

### DIFF
--- a/R/company_expected_loss.R
+++ b/R/company_expected_loss.R
@@ -62,7 +62,7 @@ company_expected_loss <- function(data,
     dplyr::mutate(
       exposure_at_default = .data$asset_portfolio_value * .data$percent_exposure
     ) %>%
-    dplyr::mutate(term = dplyr::if_else(.data$term > 5, 5, .data$term))
+    dplyr::mutate(term = dplyr::if_else(.data$term > 5, 5, as.double(.data$term)))
 
   data <- data %>%
     dplyr::mutate(lgd = loss_given_default)

--- a/R/utils-tests.R
+++ b/R/utils-tests.R
@@ -1,0 +1,3 @@
+expect_no_error <- function(object, ...) {
+  testthat::expect_error(object, regexp = NA, ...)
+}

--- a/tests/testthat/test-run_stress_test.R
+++ b/tests/testthat/test-run_stress_test.R
@@ -1,0 +1,8 @@
+test_that("works with integer passed to `term`", {
+  expect_no_error(
+    # Quietly
+    x <- suppressWarnings(capture.output(
+      run_stress_test("bonds", term = 1L)
+    ))
+  )
+})

--- a/tests/testthat/test-run_stress_test.R
+++ b/tests/testthat/test-run_stress_test.R
@@ -1,4 +1,7 @@
-test_that("works with integer passed to `term`", {
+test_that("works with `term` of type 'integer'", {
+  is_me <- identical(path.expand("~"), "/home/mauro")
+  skip_if_not(is_me)
+
   expect_no_error(
     # Quietly
     x <- suppressWarnings(capture.output(


### PR DESCRIPTION
- Closes #167

This PR fixes the bug in place with the smallest diff I could come up with. 

It does not rule out similar bugs with other arguments. For that we may convert all numeric arguments to an expected type (say integer or double), then we'll know that type will be stable everywhere. That could be in a follow up PR but first I'll investigate if indeed other arguments suffer the same problem.

--

Update:

I see no bug with any of the arguments which default looks like an integer -- `terminal_value`, `div_netprofit_prop_coef`, and `shock_year`. So I won't follow up. 

This is ready for review.