### PR TITLE
Setup infrastructure for package website

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -17,3 +17,6 @@
 ^\.github$
 ^\.Renviron$
 ^vignettes/articles$
+^_pkgdown\.yml$
+^docs$
+^pkgdown$

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -1,0 +1,33 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/master/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+on:
+  push:
+    branches: [main, master]
+    tags: ['*']
+
+name: pkgdown
+
+jobs:
+  pkgdown:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: r-lib/actions/setup-pandoc@v1
+
+      - uses: r-lib/actions/setup-r@v1
+        with:
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v1
+        with:
+          extra-packages: pkgdown
+          needs: website
+
+      - name: Deploy package
+        run: |
+          git config --local user.name "$GITHUB_ACTOR"
+          git config --local user.email "$GITHUB_ACTOR@users.noreply.github.com"
+          Rscript -e 'pkgdown::deploy_to_branch(new_process = FALSE)'

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ vignettes/*.pdf
 Desktop.ini
 *.icloud
 .Rproj.user
+docs

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -45,3 +45,4 @@ Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.1.2
+URL: https://2degreesinvesting.github.io/r2dii.climate.stress.test

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,0 +1,2 @@
+url: https://2degreesinvesting.github.io/r2dii.climate.stress.test
+


### PR DESCRIPTION
This PR adds the default infrastructure to build the pkgdown website on CI. It's all done via:

```
usetihs::use_pkgdown_github_pages()
```

To tweak this minimal website we may follow up with other PRs. The tweaks go in _pkgdown.yml (example [source](https://github.com/2DegreesInvesting/r2dii.match/blob/main/_pkgdown.yml) and [website](https://2degreesinvesting.github.io/r2dii.match)).
