### PR TITLE
Avoid NOTE: no visible binding for '<<-'

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,3 +1,9 @@
+# FIXME: Avoid NOTE: no visible binding for '<<-' assignment
+# These files are not used by the package but they are by legacy code that
+# uses the repository that hosts the package.
+^R/set_params_st\.R$
+^tests/testthat/test-set_params_st\.R$
+
 ^r2dii\.climate\.stress\.test\.Rproj$
 ^\.Rproj\.user$
 ^README\.Rmd$


### PR DESCRIPTION
This PR avoids the R CMD check NOTE: 

```
no visible binding for '<<-'﻿
```

The files it adds to .Rbuildignore are not used in the
package code. But they seem necessary for legacy code 
that uses the source code directly from the repo that
hosts this package.

REVIEWER: Please confirm this does not break code that
depends on these files.

