### PR TITLE
Remove suffix _arg from argument names, not output

### DIFF
--- a/R/run_stress_test.R
+++ b/R/run_stress_test.R
@@ -5,44 +5,44 @@
 #' vector of values to one (and only one) of the detail arguments. This will
 #' result in running the analysis multiple times in a row with the argument
 #' varied.
-#' NOTE: argument `asset_type_arg` is not iterateable.
+#' NOTE: argument `asset_type` is not iterateable.
 #'
-#' @param asset_type_arg String holding asset_type, for allowed value compare
+#' @param asset_type String holding asset_type, for allowed value compare
 #'   `asset_types_lookup`.
-#' @param lgd_senior_claims_arg Numeric, holding the loss given default for senior
+#' @param lgd_senior_claims Numeric, holding the loss given default for senior
 #'   claims, for accepted value range check `lgd_senior_claims_range_lookup`.
-#' @param lgd_subordinated_claims_arg Numeric, holding the loss given default for
+#' @param lgd_subordinated_claims Numeric, holding the loss given default for
 #'   subordinated claims, for accepted value range check
 #'   `lgd_subordinated_claims_range_lookup`.
-#' @param terminal_value_arg Numeric. A ratio to determine the share of the
+#' @param terminal_value Numeric. A ratio to determine the share of the
 #'   discounted value used in the terminal value calculation beyond the
 #'   projected time frame. For accepted range compare `terminal_value_range_lookup`.
-#' @param risk_free_rate_arg Numeric that indicates the risk free rate of interest.
+#' @param risk_free_rate Numeric that indicates the risk free rate of interest.
 #'   For accepted range compare `risk_free_rate_range_lookup`.
-#' @param discount_rate_arg Numeric, that holds the discount rate of dividends per
+#' @param discount_rate Numeric, that holds the discount rate of dividends per
 #'   year in the DCF. For accepted range compare `discount_rate_range_lookup`.
-#' @param div_netprofit_prop_coef_arg Numeric. A coefficient that determines how
+#' @param div_netprofit_prop_coef Numeric. A coefficient that determines how
 #'   strongly the future dividends propagate to the company value. For accepted
 #'   range compare `div_netprofit_prop_coef_range_lookup`.
-#' @param shock_year_arg Numeric, holding year the shock is applied. For accepted
+#' @param shock_year Numeric, holding year the shock is applied. For accepted
 #'   range compare `shock_year_range_lookup`.
-#' @param term_arg Numeric. A coefficient that determines for which maturity the
+#' @param term Numeric. A coefficient that determines for which maturity the
 #'   expected loss should be calculated in the credit risk section. For accepted
 #'   range compare `term_range_lookup`.
-#' @param company_exclusion_arg Boolean, indicating if companies provided in dataset
+#' @param company_exclusion Boolean, indicating if companies provided in dataset
 #'   excluded_companies.csv shall be excluded.
 #' @return NULL
 #' @export
-run_stress_test <- function(asset_type_arg,
-                            lgd_senior_claims_arg = 0.45,
-                            lgd_subordinated_claims_arg = 0.75,
-                            terminal_value_arg = 0,
-                            risk_free_rate_arg = 0.02,
-                            discount_rate_arg = 0.02,
-                            div_netprofit_prop_coef_arg = 1,
-                            shock_year_arg = 2030,
-                            term_arg = 2,
-                            company_exclusion_arg = TRUE) {
+run_stress_test <- function(asset_type,
+                            lgd_senior_claims = 0.45,
+                            lgd_subordinated_claims = 0.75,
+                            terminal_value = 0,
+                            risk_free_rate = 0.02,
+                            discount_rate = 0.02,
+                            div_netprofit_prop_coef = 1,
+                            shock_year = 2030,
+                            term = 2,
+                            company_exclusion = TRUE) {
   cat("Running transition risk stress test \n")
 
   args_list <- mget(names(formals()), sys.frame(sys.nframe()))
@@ -63,7 +63,7 @@ run_stress_test <- function(asset_type_arg,
     expected_loss = st_results$expected_loss,
     annual_pd_changes = st_results$annual_pd_changes,
     overall_pd_changes = st_results$overall_pd_changes,
-    asset_type = asset_type_arg,
+    asset_type = asset_type,
     calculation_level = calculation_level_lookup,
     sensitivity_analysis_vars = names(args_list),
     iter_var = iter_var
@@ -86,6 +86,7 @@ run_stress_test_iteration <- function(n, args_tibble) {
   arg_list_row <- arg_tibble_row %>%
     as.list()
 
+  arg_tibble_row <- dplyr::rename_with(arg_tibble_row, ~paste0(.x, "_arg"))
   st_result <- do.call(args = arg_list_row, what = run_stress_test_impl) %>%
     purrr::map(dplyr::bind_cols, data_y = arg_tibble_row)
 }
@@ -98,29 +99,29 @@ run_stress_test_iteration <- function(n, args_tibble) {
 #' @inheritParams run_stress_test
 #'
 #' @return A list of stress test results.
-run_stress_test_impl <- function(asset_type_arg,
-                                 lgd_senior_claims_arg,
-                                 lgd_subordinated_claims_arg,
-                                 terminal_value_arg,
-                                 risk_free_rate_arg,
-                                 discount_rate_arg,
-                                 div_netprofit_prop_coef_arg,
-                                 shock_year_arg,
-                                 term_arg,
-                                 company_exclusion_arg) {
+run_stress_test_impl <- function(asset_type,
+                                 lgd_senior_claims,
+                                 lgd_subordinated_claims,
+                                 terminal_value,
+                                 risk_free_rate,
+                                 discount_rate,
+                                 div_netprofit_prop_coef,
+                                 shock_year,
+                                 term,
+                                 company_exclusion) {
   cat("Validating input arguments. \n")
 
   validate_input_values(
-    lgd_senior_claims = lgd_senior_claims_arg,
-    lgd_subordinated_claims = lgd_subordinated_claims_arg,
-    terminal_value = terminal_value_arg,
-    risk_free_rate = risk_free_rate_arg,
-    discount_rate = discount_rate_arg,
-    div_netprofit_prop_coef = div_netprofit_prop_coef_arg,
-    shock_year = shock_year_arg,
-    term = term_arg,
-    company_exclusion = company_exclusion_arg,
-    asset_type = asset_type_arg
+    lgd_senior_claims = lgd_senior_claims,
+    lgd_subordinated_claims = lgd_subordinated_claims,
+    terminal_value = terminal_value,
+    risk_free_rate = risk_free_rate,
+    discount_rate = discount_rate,
+    div_netprofit_prop_coef = div_netprofit_prop_coef,
+    shock_year = shock_year,
+    term = term,
+    company_exclusion = company_exclusion,
+    asset_type = asset_type
   )
 
   cat("-- Configuring analysis settings. \n")
@@ -130,10 +131,10 @@ run_stress_test_impl <- function(asset_type_arg,
   calculation_level <- calculation_level_lookup
   end_year <- end_year_lookup
   time_horizon <- time_horizon_lookup
-  flat_multiplier <- assign_flat_multiplier(asset_type = asset_type_arg)
+  flat_multiplier <- assign_flat_multiplier(asset_type = asset_type)
   lgd <- assign_lgd(
-    asset_type = asset_type_arg, lgd_senior_claims = lgd_senior_claims_arg,
-    lgd_subordinated_claims = lgd_subordinated_claims_arg
+    asset_type = asset_type, lgd_senior_claims = lgd_senior_claims,
+    lgd_subordinated_claims = lgd_subordinated_claims
   )
   scenario_geography_filter <- "Global"
   scenarios_filter <- unique(
@@ -146,13 +147,13 @@ run_stress_test_impl <- function(asset_type_arg,
   cat("-- Importing and preparing input data from designated input path. \n")
 
   pacta_based_data <- read_and_prepare_project_specific_data(
-    asset_type = asset_type_arg,
+    asset_type = asset_type,
     calculation_level = calculation_level,
     time_horizon = time_horizon,
     scenario_geography_filter = scenario_geography_filter,
     scenarios_filter = scenarios_filter,
     equity_market_filter = equity_market_filter_lookup,
-    term = term_arg
+    term = term
   )
 
   project_specific_data_list <- pacta_based_data$data_list
@@ -161,9 +162,9 @@ run_stress_test_impl <- function(asset_type_arg,
   project_agnostic_data_list <- read_and_prepare_project_agnostic_data(
     start_year = start_year,
     end_year = end_year,
-    company_exclusion = company_exclusion_arg,
+    company_exclusion = company_exclusion,
     scenario_geography_filter = scenario_geography_filter,
-    asset_type = asset_type_arg
+    asset_type = asset_type
   )
 
   input_data_list <- c(project_specific_data_list, project_agnostic_data_list) %>%
@@ -174,14 +175,14 @@ run_stress_test_impl <- function(asset_type_arg,
       scenario_geography_filter = scenario_geography_filter
     )
 
-  if (asset_type_arg == "loans") {
+  if (asset_type == "loans") {
     input_data_list$financial_data <- input_data_list$financial_data %>%
       dplyr::mutate(company_name = stringr::str_to_lower(.data$company_name))
   }
 
   report_company_drops(
     data_list = input_data_list,
-    asset_type = asset_type_arg
+    asset_type = asset_type
   )
 
   check_scenario_availability(
@@ -195,13 +196,13 @@ run_stress_test_impl <- function(asset_type_arg,
   transition_scenario <- generate_transition_shocks(
     start_of_analysis = start_year,
     end_of_analysis = end_year,
-    shock_years = shock_year_arg
+    shock_years = shock_year
   )
 
   cat("-- Calculating market risk. \n")
 
   annual_profits <- calculate_annual_profits(
-    asset_type = asset_type_arg,
+    asset_type = asset_type,
     input_data_list = input_data_list,
     scenario_to_follow_baseline = scenario_to_follow_baseline,
     scenario_to_follow_ls = scenario_to_follow_ls,
@@ -209,11 +210,11 @@ run_stress_test_impl <- function(asset_type_arg,
     start_year = start_year,
     end_year = end_year,
     time_horizon = time_horizon,
-    discount_rate = discount_rate_arg
+    discount_rate = discount_rate
   )
 
   exposure_by_technology_and_company <- calculate_exposure_by_technology_and_company(
-    asset_type = asset_type_arg,
+    asset_type = asset_type,
     input_data_list = input_data_list,
     start_year = start_year,
     scenario_to_follow_ls = scenario_to_follow_ls
@@ -221,9 +222,9 @@ run_stress_test_impl <- function(asset_type_arg,
 
   results <- company_asset_value_at_risk(
     data = annual_profits,
-    terminal_value = terminal_value_arg,
+    terminal_value = terminal_value,
     shock_scenario = transition_scenario,
-    div_netprofit_prop_coef = div_netprofit_prop_coef_arg,
+    div_netprofit_prop_coef = div_netprofit_prop_coef,
     plan_carsten = exposure_by_technology_and_company,
     port_aum = port_aum,
     flat_multiplier = flat_multiplier,
@@ -236,7 +237,7 @@ run_stress_test_impl <- function(asset_type_arg,
     calculate_pd_change_overall(
       shock_year = transition_scenario$year_of_shock,
       end_of_analysis = end_year,
-      risk_free_interest_rate = risk_free_rate_arg
+      risk_free_interest_rate = risk_free_rate
     )
 
   # TODO: ADO 879 - note which companies produce missing results due to
@@ -257,7 +258,7 @@ run_stress_test_impl <- function(asset_type_arg,
     data = annual_profits,
     shock_year = transition_scenario$year_of_shock,
     end_of_analysis = end_year,
-    risk_free_interest_rate = risk_free_rate_arg
+    risk_free_interest_rate = risk_free_rate
   )
 
   # TODO: ADO 879 - note which companies produce missing results due to

--- a/R/utils.R
+++ b/R/utils.R
@@ -347,7 +347,7 @@ get_iter_var <- function(args_list) {
   } else if (nrow(iterate_arg) == 1) {
     iter_var <- iterate_arg$name
 
-    if (iter_var == "asset_type_arg") {
+    if (iter_var == "asset_type") {
       rlang::abort(
         "Cannot iterate over argument asset_type")
     }

--- a/R/write_results.R
+++ b/R/write_results.R
@@ -26,6 +26,7 @@ write_stress_test_results <- function(results, expected_loss,
 
   results_path <- file.path(get_st_data_path("ST_PROJECT_FOLDER"), "outputs")
 
+  sensitivity_analysis_vars <- paste0(sensitivity_analysis_vars, "_arg")
   results %>%
     write_results_new(
       path_to_results = results_path,

--- a/man/run_stress_test.Rd
+++ b/man/run_stress_test.Rd
@@ -5,51 +5,51 @@
 \title{Run stress testing for provided asset type.}
 \usage{
 run_stress_test(
-  asset_type_arg,
-  lgd_senior_claims_arg = 0.45,
-  lgd_subordinated_claims_arg = 0.75,
-  terminal_value_arg = 0,
-  risk_free_rate_arg = 0.02,
-  discount_rate_arg = 0.02,
-  div_netprofit_prop_coef_arg = 1,
-  shock_year_arg = 2030,
-  term_arg = 2,
-  company_exclusion_arg = TRUE
+  asset_type,
+  lgd_senior_claims = 0.45,
+  lgd_subordinated_claims = 0.75,
+  terminal_value = 0,
+  risk_free_rate = 0.02,
+  discount_rate = 0.02,
+  div_netprofit_prop_coef = 1,
+  shock_year = 2030,
+  term = 2,
+  company_exclusion = TRUE
 )
 }
 \arguments{
-\item{asset_type_arg}{String holding asset_type, for allowed value compare
+\item{asset_type}{String holding asset_type, for allowed value compare
 \code{asset_types_lookup}.}
 
-\item{lgd_senior_claims_arg}{Numeric, holding the loss given default for senior
+\item{lgd_senior_claims}{Numeric, holding the loss given default for senior
 claims, for accepted value range check \code{lgd_senior_claims_range_lookup}.}
 
-\item{lgd_subordinated_claims_arg}{Numeric, holding the loss given default for
+\item{lgd_subordinated_claims}{Numeric, holding the loss given default for
 subordinated claims, for accepted value range check
 \code{lgd_subordinated_claims_range_lookup}.}
 
-\item{terminal_value_arg}{Numeric. A ratio to determine the share of the
+\item{terminal_value}{Numeric. A ratio to determine the share of the
 discounted value used in the terminal value calculation beyond the
 projected time frame. For accepted range compare \code{terminal_value_range_lookup}.}
 
-\item{risk_free_rate_arg}{Numeric that indicates the risk free rate of interest.
+\item{risk_free_rate}{Numeric that indicates the risk free rate of interest.
 For accepted range compare \code{risk_free_rate_range_lookup}.}
 
-\item{discount_rate_arg}{Numeric, that holds the discount rate of dividends per
+\item{discount_rate}{Numeric, that holds the discount rate of dividends per
 year in the DCF. For accepted range compare \code{discount_rate_range_lookup}.}
 
-\item{div_netprofit_prop_coef_arg}{Numeric. A coefficient that determines how
+\item{div_netprofit_prop_coef}{Numeric. A coefficient that determines how
 strongly the future dividends propagate to the company value. For accepted
 range compare \code{div_netprofit_prop_coef_range_lookup}.}
 
-\item{shock_year_arg}{Numeric, holding year the shock is applied. For accepted
+\item{shock_year}{Numeric, holding year the shock is applied. For accepted
 range compare \code{shock_year_range_lookup}.}
 
-\item{term_arg}{Numeric. A coefficient that determines for which maturity the
+\item{term}{Numeric. A coefficient that determines for which maturity the
 expected loss should be calculated in the credit risk section. For accepted
 range compare \code{term_range_lookup}.}
 
-\item{company_exclusion_arg}{Boolean, indicating if companies provided in dataset
+\item{company_exclusion}{Boolean, indicating if companies provided in dataset
 excluded_companies.csv shall be excluded.}
 }
 \description{
@@ -58,5 +58,5 @@ understand sensitivities of the scenarios, in which case the user may pass a
 vector of values to one (and only one) of the detail arguments. This will
 result in running the analysis multiple times in a row with the argument
 varied.
-NOTE: argument \code{asset_type_arg} is not iterateable.
+NOTE: argument \code{asset_type} is not iterateable.
 }

--- a/man/run_stress_test_impl.Rd
+++ b/man/run_stress_test_impl.Rd
@@ -5,51 +5,51 @@
 \title{Run stress testing for provided asset type.}
 \usage{
 run_stress_test_impl(
-  asset_type_arg,
-  lgd_senior_claims_arg,
-  lgd_subordinated_claims_arg,
-  terminal_value_arg,
-  risk_free_rate_arg,
-  discount_rate_arg,
-  div_netprofit_prop_coef_arg,
-  shock_year_arg,
-  term_arg,
-  company_exclusion_arg
+  asset_type,
+  lgd_senior_claims,
+  lgd_subordinated_claims,
+  terminal_value,
+  risk_free_rate,
+  discount_rate,
+  div_netprofit_prop_coef,
+  shock_year,
+  term,
+  company_exclusion
 )
 }
 \arguments{
-\item{asset_type_arg}{String holding asset_type, for allowed value compare
+\item{asset_type}{String holding asset_type, for allowed value compare
 \code{asset_types_lookup}.}
 
-\item{lgd_senior_claims_arg}{Numeric, holding the loss given default for senior
+\item{lgd_senior_claims}{Numeric, holding the loss given default for senior
 claims, for accepted value range check \code{lgd_senior_claims_range_lookup}.}
 
-\item{lgd_subordinated_claims_arg}{Numeric, holding the loss given default for
+\item{lgd_subordinated_claims}{Numeric, holding the loss given default for
 subordinated claims, for accepted value range check
 \code{lgd_subordinated_claims_range_lookup}.}
 
-\item{terminal_value_arg}{Numeric. A ratio to determine the share of the
+\item{terminal_value}{Numeric. A ratio to determine the share of the
 discounted value used in the terminal value calculation beyond the
 projected time frame. For accepted range compare \code{terminal_value_range_lookup}.}
 
-\item{risk_free_rate_arg}{Numeric that indicates the risk free rate of interest.
+\item{risk_free_rate}{Numeric that indicates the risk free rate of interest.
 For accepted range compare \code{risk_free_rate_range_lookup}.}
 
-\item{discount_rate_arg}{Numeric, that holds the discount rate of dividends per
+\item{discount_rate}{Numeric, that holds the discount rate of dividends per
 year in the DCF. For accepted range compare \code{discount_rate_range_lookup}.}
 
-\item{div_netprofit_prop_coef_arg}{Numeric. A coefficient that determines how
+\item{div_netprofit_prop_coef}{Numeric. A coefficient that determines how
 strongly the future dividends propagate to the company value. For accepted
 range compare \code{div_netprofit_prop_coef_range_lookup}.}
 
-\item{shock_year_arg}{Numeric, holding year the shock is applied. For accepted
+\item{shock_year}{Numeric, holding year the shock is applied. For accepted
 range compare \code{shock_year_range_lookup}.}
 
-\item{term_arg}{Numeric. A coefficient that determines for which maturity the
+\item{term}{Numeric. A coefficient that determines for which maturity the
 expected loss should be calculated in the credit risk section. For accepted
 range compare \code{term_range_lookup}.}
 
-\item{company_exclusion_arg}{Boolean, indicating if companies provided in dataset
+\item{company_exclusion}{Boolean, indicating if companies provided in dataset
 excluded_companies.csv shall be excluded.}
 }
 \value{

--- a/nonstandard/QA_scripts/change_check_cb.R
+++ b/nonstandard/QA_scripts/change_check_cb.R
@@ -57,14 +57,14 @@ check_all_equal <- function(old_results, new_results) {
 
 ### 1. check out master branch of repo (or whichever branch you want to use as reference)
 devtools::load_all()
-run_stress_test(asset_type_arg = "bonds")
+run_stress_test(asset_type = "bonds")
 
 ### 2. run the following lines to obtain results
 old_results <- import_asset_results()
 
 ### 3. check out dev branch of repo (or whichever branch you want to use as comparison)
 devtools::load_all()
-run_stress_test(asset_type_arg = "bonds")
+run_stress_test(asset_type = "bonds")
 
 ### 4. run the following lines to run script or equity and bonds and obtain results
 new_results <- import_asset_results()
@@ -81,11 +81,11 @@ check
 import_asset_results <- function() {
   results_path <- file.path(get_st_data_path("ST_PROJECT_FOLDER"), "outputs")
 
-  bonds_results_company <- readr::read_csv(file.path(results_path, "stress_test_results_bonds_comp_shock_year_arg.csv"))
-  bonds_results_port <- readr::read_csv(file.path(results_path, "stress_test_results_bonds_port_shock_year_arg.csv"))
-  bonds_expected_loss <- readr::read_csv(file.path(results_path, "stress_test_results_bonds_comp_el_shock_year_arg.csv"))
-  bonds_annual_pd_changes_sector <- readr::read_csv(file.path(results_path, "stress_test_results_bonds_sector_pd_changes_annual_shock_year_arg.csv"))
-  bonds_overall_pd_changes_sector <- readr::read_csv(file.path(results_path, "stress_test_results_bonds_sector_pd_changes_overall_shock_year_arg.csv"))
+  bonds_results_company <- readr::read_csv(file.path(results_path, "stress_test_results_bonds_comp_shock_year.csv"))
+  bonds_results_port <- readr::read_csv(file.path(results_path, "stress_test_results_bonds_port_shock_year.csv"))
+  bonds_expected_loss <- readr::read_csv(file.path(results_path, "stress_test_results_bonds_comp_el_shock_year.csv"))
+  bonds_annual_pd_changes_sector <- readr::read_csv(file.path(results_path, "stress_test_results_bonds_sector_pd_changes_annual_shock_year.csv"))
+  bonds_overall_pd_changes_sector <- readr::read_csv(file.path(results_path, "stress_test_results_bonds_sector_pd_changes_overall_shock_year.csv"))
 
   asset_results <- list(
     bonds_results_company = bonds_results_company,
@@ -107,14 +107,14 @@ import_asset_results <- function() {
 
 ### 1. check out master branch of repo (or whichever branch you want to use as reference)
 devtools::load_all()
-run_stress_test(asset_type_arg = "bonds", shock_year_arg = c(2025, 2030, 2033))
+run_stress_test(asset_type = "bonds", shock_year = c(2025, 2030, 2033))
 
 ### 2. run the following lines to obtain results
 old_results <- import_asset_results()
 
 ### 3. check out dev branch of repo (or whichever branch you want to use as comparison)
 devtools::load_all()
-run_stress_test(asset_type_arg = "bonds", shock_year_arg = c(2025, 2030, 2033))
+run_stress_test(asset_type = "bonds", shock_year = c(2025, 2030, 2033))
 
 ### 4. run the following lines to run script or equity and bonds and obtain results
 new_results <- import_asset_results()

--- a/nonstandard/QA_scripts/change_check_cl.R
+++ b/nonstandard/QA_scripts/change_check_cl.R
@@ -55,14 +55,14 @@ check_all_equal <- function(old_results, new_results) {
 
 ### 1. check out master branch of repo (or whichever branch you want to use as reference)
 devtools::load_all()
-run_stress_test(asset_type_arg = "loans")
+run_stress_test(asset_type = "loans")
 
 ### 2. run the following lines to obtain results
 old_results <- import_asset_results()
 
 ### 3. check out dev branch of repo (or whichever branch you want to use as comparison)
 devtools::load_all()
-run_stress_test(asset_type_arg = "loans")
+run_stress_test(asset_type = "loans")
 
 
 ### 4. run the following lines to run script or equity and bonds and obtain results

--- a/nonstandard/QA_scripts/change_check_eq.R
+++ b/nonstandard/QA_scripts/change_check_eq.R
@@ -57,14 +57,14 @@ check_all_equal <- function(old_results, new_results) {
 
 ### 1. check out master branch of repo (or whichever branch you want to use as reference)
 devtools::load_all()
-run_stress_test(asset_type_arg = "equity")
+run_stress_test(asset_type = "equity")
 
 ### 2. run the following lines to obtain results
 old_results <- import_asset_results()
 
 ### 3. check out dev branch of repo (or whichever branch you want to use as comparison)
 devtools::load_all()
-run_stress_test(asset_type_arg = "equity")
+run_stress_test(asset_type = "equity")
 
 
 ### 4. run the following lines to run script or equity and bonds and obtain results

--- a/tests/testthat/test-run_stress_test.R
+++ b/tests/testthat/test-run_stress_test.R
@@ -1,11 +1,15 @@
-test_that("works with `term` of type 'integer'", {
+test_that("output includes argument names with suffix '_arg'", {
   is_me <- identical(path.expand("~"), "/home/mauro")
   skip_if_not(is_me)
 
-  expect_no_error(
-    # Quietly
-    x <- suppressWarnings(capture.output(
-      run_stress_test("bonds", term_arg = 1L)
-    ))
-  )
+  # Refresh
+  out_path <- fs::path(Sys.getenv("ST_PROJECT_FOLDER"), "outputs")
+  if (fs::dir_exists(out_path)) fs::dir_delete(out_path)
+
+  x <- suppressWarnings(capture.output(
+    run_stress_test("bonds", term = 1:2)
+  ))
+
+  data <- purrr::map(fs::dir_ls(out_path), readr::read_csv, col_types = list())
+  expect_true(all(purrr::map_lgl(data, ~rlang::has_name(.x, "term_arg"))))
 })


### PR DESCRIPTION
This remove the suffix '_arg' from the signature of `run_stress_test()`
but leave it in the name of the output columns.

I aimed to minimize the diff. 

I think we should refactor as I think there is a simpler way to the job. 
In general, I think the output is easier to grow rowwise than colwise.
If we need columns we can pivot_wider() at the end. But I suspect the 
longer format is easier to pass to ggplot, and filter with
dplyr::filter().

