### PR TITLE
move r2dii.plot to suggst

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,7 +29,6 @@ Imports:
     purrr,
     r2dii.analysis,
     r2dii.data,
-    r2dii.plot,
     readr,
     readxl,
     rlang,
@@ -39,6 +38,7 @@ Imports:
     withr,
     zoo
 Suggests: 
+    r2dii.plot,
     testthat (>= 3.0.0)
 Config/testthat/edition: 3
 Encoding: UTF-8


### PR DESCRIPTION
microchange to force users to install less deps.
config and ggplot are also not needed for user workflows, but since the are used in webtool they cannot be removed from imports yet.