### PR TITLE
Update website's reference

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,2 +1,8 @@
 url: https://2degreesinvesting.github.io/r2dii.climate.stress.test
 
+reference:
+- title: All functions
+  contents:
+  - run_prep_calculation_loans
+  - run_stress_test
+  - check_financial_data


### PR DESCRIPTION
Show user-facing functions only.

We can tweak the website a bit more and make it similar to other packages of the r2dii family, e.g. https://2degreesinvesting.github.io/r2dii.data/

![image](https://user-images.githubusercontent.com/5856545/141342969-e6f10284-809b-484f-8b0d-8823663a6034.png)

--

And we can set it up so that we host the released version at the normal URL, and the development version at ULR/dev:

![image](https://user-images.githubusercontent.com/5856545/141343208-47bdc944-35b5-4a87-9a22-b5dbde9ee7ff.png)
