### PR TITLE
2846 rm unneeded output cols

### DIFF
--- a/R/write_results.R
+++ b/R/write_results.R
@@ -40,13 +40,10 @@ write_stress_test_results <- function(results, expected_loss,
   expected_loss <- expected_loss %>%
     dplyr::select(
       .data$scenario_name, .data$scenario_geography, .data$investor_name,
-      .data$portfolio_name, .data$company_name, .data$id, .data$ald_sector,
-      .data$equity_0_baseline, .data$equity_0_late_sudden, .data$debt,
-      .data$volatility, .data$risk_free_rate, .data$term, .data$Survival_baseline,
-      .data$Survival_late_sudden, .data$PD_baseline, .data$PD_late_sudden,
-      .data$PD_change, .data$pd, .data$lgd, .data$percent_exposure, # TODO: keep all tehse PDs??
-      .data$exposure_at_default, .data$expected_loss_baseline,
-      .data$expected_loss_late_sudden, !!!rlang::syms(sensitivity_analysis_vars)
+      .data$portfolio_name, .data$company_name, .data$ald_sector,
+      .data$pd, .data$PD_change, .data$lgd, .data$exposure_at_default,
+      .data$expected_loss_baseline, .data$expected_loss_late_sudden,
+      !!!rlang::syms(sensitivity_analysis_vars)
     ) %>%
     dplyr::arrange(
       .data$scenario_geography, .data$scenario_name, .data$investor_name,

--- a/R/write_results.R
+++ b/R/write_results.R
@@ -57,7 +57,7 @@ write_stress_test_results <- function(results, expected_loss,
     report_all_duplicate_kinds(
       composite_unique_cols = c(
         "scenario_name", "scenario_geography", "investor_name", "portfolio_name",
-        "company_name", "id", "ald_sector", "term",
+        "company_name", "ald_sector",
         sensitivity_analysis_vars
       )
     ) %>%


### PR DESCRIPTION
closes ADO 2846: https://dev.azure.com/2DegreesInvesting/2DegreesInvesting/_workitems/edit/2846

This PR removes unnecessary output columns from the expected loss output to make the result file more digestible

change checks pass except for expected loss files, which is of course expected

also fyi @fariiaakh @jakubcervenka 