### PR TITLE
Output path

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -10,6 +10,7 @@ ST_DATA_PATH=/a/path
 # Where to save project specific inputs and outputs?
 # For example, for bonds (fastest) see 2DII's Dropbox at 
 # PortCheck_v2/10_Projects/ST_TESTING_BONDS
-ST_PROJECT_FOLDER=/another/path
+ST_PROJECT_FOLDER_INPUT=/another/path/inputs
+ST_PROJECT_FOLDER_OUTPUT=/another/path/outputs
 ```
 

--- a/R/lookup.R
+++ b/R/lookup.R
@@ -143,4 +143,4 @@ p4b_scenarios_lookup <- c("target_b2ds", "target_cps", "target_rts",
                           "target_sds")
 
 
-path_vars_lookup <- c("input_path_project_agnostic", "input_path_project_specific")
+path_vars_lookup <- c("input_path_project_agnostic", "input_path_project_specific", "output_path")

--- a/R/lookup.R
+++ b/R/lookup.R
@@ -143,4 +143,4 @@ p4b_scenarios_lookup <- c("target_b2ds", "target_cps", "target_rts",
                           "target_sds")
 
 
-path_vars_lookup <- c("data_path_project_agnostic", "data_path_project_specific")
+path_vars_lookup <- c("input_path_project_agnostic", "input_path_project_specific")

--- a/R/read_and_prepare.R
+++ b/R/read_and_prepare.R
@@ -86,7 +86,7 @@ read_and_prepare_project_specific_data <- function(asset_type, calculation_level
                                                    scenarios_filter, equity_market_filter,
                                                    term, path) {
   pacta_results <- read_pacta_results(
-    path = file.path(path, "inputs", paste0(stringr::str_to_title(asset_type), "_results_", calculation_level, ".rda")),
+    path = file.path(path, paste0(stringr::str_to_title(asset_type), "_results_", calculation_level, ".rda")),
     level = calculation_level
   )
 
@@ -104,7 +104,7 @@ read_and_prepare_project_specific_data <- function(asset_type, calculation_level
     # TODO: next version to allow term input on holding/company level
     dplyr::mutate(term = term)
 
-  sector_exposures <- read_sector_exposures(file.path(path, "inputs", "overview_portfolio.rda")) %>%
+  sector_exposures <- read_sector_exposures(file.path(path, "overview_portfolio.rda")) %>%
     wrangle_and_check_sector_exposures(asset_type = asset_type)
   # TODO: potentially convert currencies to USD or at least common currency
 

--- a/R/read_and_prepare.R
+++ b/R/read_and_prepare.R
@@ -26,14 +26,13 @@ read_and_prepare_project_agnostic_data <- function(start_year, end_year, company
   )
 
   if (company_exclusion) {
-    validate_file_exists(file.path(path, "exclude-companies.csv"))
-    excluded_companies <- readr::read_csv(
-      file.path(path, "exclude-companies.csv"),
-      col_types = readr::cols(
-        company_name = "c",
-        technology = "c"
+    excluded_companies <- validate_file_exists(file.path(path, "exclude-companies.csv")) %>%
+      readr::read_csv(
+        col_types = readr::cols(
+          company_name = "c",
+          technology = "c"
+        )
       )
-    )
   } else {
     excluded_companies <- NULL
   }
@@ -59,7 +58,7 @@ read_and_prepare_project_agnostic_data <- function(start_year, end_year, company
   financial_data <- read_financial_data(
     path = file.path(get_st_data_path(), "prewrangled_financial_data_stress_test.csv")
   ) %>%
-  check_financial_data(asset_type = asset_type)
+    check_financial_data(asset_type = asset_type)
 
   return(list(
     capacity_factors_power = capacity_factors_power,
@@ -86,7 +85,6 @@ read_and_prepare_project_specific_data <- function(asset_type, calculation_level
                                                    time_horizon, scenario_geography_filter,
                                                    scenarios_filter, equity_market_filter,
                                                    term, path) {
-
   pacta_results <- read_pacta_results(
     path = file.path(path, "inputs", paste0(stringr::str_to_title(asset_type), "_results_", calculation_level, ".rda")),
     level = calculation_level
@@ -130,9 +128,8 @@ read_and_prepare_project_specific_data <- function(asset_type, calculation_level
 #'
 #' @return A tibble holding sector exposure data
 read_sector_exposures <- function(path) {
-  validate_file_exists(path)
-
-  sector_exposures <- readr::read_rds(path)
+  sector_exposures <- validate_file_exists(path) %>%
+    readr::read_rds()
 
   validate_data_has_expected_cols(
     data = sector_exposures,

--- a/R/read_capacity_factors.R
+++ b/R/read_capacity_factors.R
@@ -18,10 +18,9 @@ read_capacity_factors <- function(path = NULL,
   version_allowed <- version %in% c("old", "new")
   stopifnot(version_allowed)
 
-  validate_file_exists(file.path(path))
-
   # TODO: once the input is in long format the expected col types can be set
-  data <- readr::read_csv(path, col_types = readr::cols())
+  data <- validate_file_exists(path) %>%
+    readr::read_csv(col_types = readr::cols())
 
   if (identical(version, "old")) {
     # FIXME: Since we only ever have one file as input so far, I am leaving the

--- a/R/read_financial_data.R
+++ b/R/read_financial_data.R
@@ -10,10 +10,8 @@
 read_financial_data <- function(path = NULL) {
   path %||% stop("Must provide 'path'")
 
-  validate_file_exists(file.path(path))
-
-  data <- readr::read_csv(
-    path,
+  data <- validate_file_exists(file.path(path)) %>%
+  readr::read_csv(
     col_types = readr::cols_only(
       company_name = "c",
       company_id = "d",

--- a/R/read_ngfs_carbon_tax.R
+++ b/R/read_ngfs_carbon_tax.R
@@ -10,10 +10,8 @@
 read_ngfs_carbon_tax <- function(path = NULL) {
   path %||% stop("Must provide 'path'")
 
-  validate_file_exists(file.path(path))
-
-  data <- readr::read_csv(
-    path,
+  data <- validate_file_exists(path) %>%
+    readr::read_csv(
     col_types = readr::cols(
       year = "d",
       model = "c",

--- a/R/read_pacta_results.R
+++ b/R/read_pacta_results.R
@@ -18,9 +18,8 @@ read_pacta_results <- function(path = NULL,
   level_allowed <- level %in% c("company", "portfolio")
   stopifnot(level_allowed)
 
-  validate_file_exists(file.path(path))
-
-  data <- readr::read_rds(path)
+  data <- validate_file_exists(path) %>%
+    readr::read_rds()
 
   expected_columns <- c(
     "investor_name", "portfolio_name", "scenario", "allocation",

--- a/R/read_price_data.R
+++ b/R/read_price_data.R
@@ -42,10 +42,9 @@ read_price_data <- function(path,
 #'
 #' @export
 read_price_data_internal <- function(path) {
-  validate_file_exists(path)
 
-  data <- readr::read_csv(
-    path,
+  data <- validate_file_exists(path) %>%
+    readr::read_csv(
     col_types = readr::cols(
       year = "d",
       source = "c",
@@ -78,10 +77,10 @@ read_price_data_internal <- function(path) {
 #'
 #' @export
 read_price_data_internal_old <- function(path) {
-  validate_file_exists(path)
 
-  data <- readr::read_csv(
-    path,
+
+  data <- validate_file_exists(path) %>%
+    readr::read_csv(
     col_types = readr::cols(
       year = "d",
       sector = "c",

--- a/R/read_scenario_data.R
+++ b/R/read_scenario_data.R
@@ -7,19 +7,20 @@
 #' @return A tibble holding scenario data.
 read_scenario_data <- function(path) {
 
-  validate_file_exists(path)
-
-  scenario_data <- readr::read_csv(path, col_types = readr::cols(
-    scenario_source = "c",
-    scenario_geography = "c",
-    scenario = "c",
-    ald_sector = "c",
-    units = "c",
-    technology = "c",
-    year = "d",
-    direction = "c",
-    fair_share_perc = "d"
-  ))
+  scenario_data <- validate_file_exists(path) %>%
+    readr::read_csv(
+      col_types = readr::cols(
+        scenario_source = "c",
+        scenario_geography = "c",
+        scenario = "c",
+        ald_sector = "c",
+        units = "c",
+        technology = "c",
+        year = "d",
+        direction = "c",
+        fair_share_perc = "d"
+      )
+    )
 
   validate_data_has_expected_cols(
     data = scenario_data,

--- a/R/read_transition_scenarios.R
+++ b/R/read_transition_scenarios.R
@@ -18,10 +18,8 @@ read_transition_scenarios <- function(path = NULL,
   start_of_analysis %||% stop("Must provide 'start_of_analysis'")
   end_of_analysis %||% stop("Must provide 'end_of_analysis'")
 
-  validate_file_exists(file.path(path))
-
-  data <- readr::read_csv(
-    path,
+  data <- validate_file_exists(path) %>%
+    readr::read_csv(
     col_types = readr::cols(
       scenario_name = "c",
       year_of_shock = "d",

--- a/R/run_prep_calculation_loans.R
+++ b/R/run_prep_calculation_loans.R
@@ -5,7 +5,7 @@
 #' @param data_prep_output_path Path where results are written.
 #'   NOTE: This is a workflow that is needed exclusively in preparation of
 #'   [run_stress_test()] for loan books. It creates input data for the stress
-#'   test. A recommended setting is to set data_prep_output_path to to the same
+#'   test. A recommended setting is to set `data_prep_output_path` to to the same
 #'   path as `input_path_project_specific`.
 #' @param credit_type Type of credit. For accepted values please compare
 #'   `credit_type_lookup`.

--- a/R/run_prep_calculation_loans.R
+++ b/R/run_prep_calculation_loans.R
@@ -259,7 +259,7 @@ run_prep_calculation_loans <- function(input_path_project_specific,
 
   portfolio_overview %>%
     saveRDS(
-      file.path(output, "overview_portfolio.rda")
+      file.path(output_path, "overview_portfolio.rda")
     )
 
   #### Calculate unweighted company level PACTA results-------------------------

--- a/R/run_prep_calculation_loans.R
+++ b/R/run_prep_calculation_loans.R
@@ -1,6 +1,12 @@
 #' Run stress testing data preparation for loans
 #'
+#'
 #' @inheritParams run_stress_test
+#' @param data_prep_output_path Path where results are written.
+#'   NOTE: This is a workflow that is needed exclusively in preparation of
+#'   [run_stress_test()] for loan books. It creates input data for the stress
+#'   test. A recommended setting is to set data_prep_output_path to to the same
+#'   path as `input_path_project_specific`.
 #' @param credit_type Type of credit. For accepted values please compare
 #'   `credit_type_lookup`.
 #'
@@ -8,7 +14,7 @@
 #' @export
 run_prep_calculation_loans <- function(input_path_project_specific,
                                        input_path_project_agnostic,
-                                       output_path,
+                                       data_prep_output_path,
                                        credit_type = "outstanding") {
 
   #### Validate input-----------------------------------------------------------
@@ -259,7 +265,7 @@ run_prep_calculation_loans <- function(input_path_project_specific,
 
   portfolio_overview %>%
     saveRDS(
-      file.path(output_path, "overview_portfolio.rda")
+      file.path(data_prep_output_path, "overview_portfolio.rda")
     )
 
   #### Calculate unweighted company level PACTA results-------------------------
@@ -319,7 +325,7 @@ run_prep_calculation_loans <- function(input_path_project_specific,
 
   loans_results_company %>%
     saveRDS(
-      file.path(output_path, "Loans_results_company.rda")
+      file.path(data_prep_output_path, "Loans_results_company.rda")
     )
 
 }

--- a/R/run_prep_calculation_loans.R
+++ b/R/run_prep_calculation_loans.R
@@ -8,6 +8,7 @@
 #' @export
 run_prep_calculation_loans <- function(input_path_project_specific,
                                        input_path_project_agnostic,
+                                       output_path,
                                        credit_type = "outstanding") {
 
   #### Validate input-----------------------------------------------------------
@@ -18,7 +19,7 @@ run_prep_calculation_loans <- function(input_path_project_specific,
 
   #### Load input data sets-----------------------------------------------------
   # raw loan book
-  loanbook <- validate_file_exists(file.path(input_path_project_specific, "inputs", paste0("raw_loanbook.csv"))) %>%
+  loanbook <- validate_file_exists(file.path(input_path_project_specific, "raw_loanbook.csv")) %>%
     readr::read_csv(
       col_types = readr::cols(
         id_loan = "c",
@@ -44,7 +45,7 @@ run_prep_calculation_loans <- function(input_path_project_specific,
     )
 
   # matched loan book
-  matched <- validate_file_exists(file.path(input_path_project_specific, "inputs", "matched_loan_book.csv")) %>%
+  matched <- validate_file_exists(file.path(input_path_project_specific, "matched_loan_book.csv")) %>%
     readr::read_csv(
       col_types = readr::cols_only(
         id_loan = "c",
@@ -258,7 +259,7 @@ run_prep_calculation_loans <- function(input_path_project_specific,
 
   portfolio_overview %>%
     saveRDS(
-      file.path(input_path_project_specific, "inputs", "overview_portfolio.rda")
+      file.path(output, "overview_portfolio.rda")
     )
 
   #### Calculate unweighted company level PACTA results-------------------------
@@ -318,7 +319,7 @@ run_prep_calculation_loans <- function(input_path_project_specific,
 
   loans_results_company %>%
     saveRDS(
-      file.path(input_path_project_specific, "inputs", "Loans_results_company.rda")
+      file.path(output_path, "Loans_results_company.rda")
     )
 
 }

--- a/R/run_prep_calculation_loans.R
+++ b/R/run_prep_calculation_loans.R
@@ -6,8 +6,8 @@
 #'
 #' @return NULL
 #' @export
-run_prep_calculation_loans <- function(data_path_project_specific,
-                                       data_path_project_agnostic,
+run_prep_calculation_loans <- function(input_path_project_specific,
+                                       input_path_project_agnostic,
                                        credit_type = "outstanding") {
 
   #### Validate input-----------------------------------------------------------
@@ -18,9 +18,9 @@ run_prep_calculation_loans <- function(data_path_project_specific,
 
   #### Load input data sets-----------------------------------------------------
   # raw loan book
-  validate_file_exists(file.path(data_path_project_specific, "inputs", paste0("raw_loanbook.csv")))
+  validate_file_exists(file.path(input_path_project_specific, "inputs", paste0("raw_loanbook.csv")))
   loanbook <- readr::read_csv(
-    file.path(data_path_project_specific, "inputs", paste0("raw_loanbook.csv")),
+    file.path(input_path_project_specific, "inputs", paste0("raw_loanbook.csv")),
     col_types = readr::cols(
       id_loan = "c",
       id_direct_loantaker = "c",
@@ -45,9 +45,9 @@ run_prep_calculation_loans <- function(data_path_project_specific,
   )
 
   # matched loan book
-  validate_file_exists(file.path(data_path_project_specific, "inputs", "matched_loan_book.csv"))
+  validate_file_exists(file.path(input_path_project_specific, "inputs", "matched_loan_book.csv"))
   matched  <- readr::read_csv(
-    file.path(data_path_project_specific, "inputs", "matched_loan_book.csv"),
+    file.path(input_path_project_specific, "inputs", "matched_loan_book.csv"),
     col_types = readr::cols_only(
       id_loan = "c",
       id_direct_loantaker = "c",
@@ -84,16 +84,16 @@ run_prep_calculation_loans <- function(data_path_project_specific,
   regions <- r2dii.data::region_isos
 
   # Production forecast data
-  validate_file_exists(file.path(data_path_project_agnostic, "2021-07-15_AR_2020Q4_PACTA-Data (3).xlsx"))
+  validate_file_exists(file.path(input_path_project_agnostic, "2021-07-15_AR_2020Q4_PACTA-Data (3).xlsx"))
   production_forecast_data <- readxl::read_xlsx(
-    file.path(data_path_project_agnostic, "2021-07-15_AR_2020Q4_PACTA-Data (3).xlsx"),
+    file.path(input_path_project_agnostic, "2021-07-15_AR_2020Q4_PACTA-Data (3).xlsx"),
     sheet = "Company Indicators - PACTA"
   )
 
   # Scenario data - market share
-  validate_file_exists(file.path(data_path_project_agnostic, "scenario_2020.csv"))
+  validate_file_exists(file.path(input_path_project_agnostic, "scenario_2020.csv"))
   scenario_data_market_share <- readr::read_csv(
-    file.path(data_path_project_agnostic, glue::glue("scenario_2020.csv")),
+    file.path(input_path_project_agnostic, glue::glue("scenario_2020.csv")),
     col_types = readr::cols(
       scenario_source = "c",
       scenario = "c",
@@ -262,7 +262,7 @@ run_prep_calculation_loans <- function(data_path_project_specific,
 
   portfolio_overview %>%
     saveRDS(
-      file.path(data_path_project_specific, "inputs", "overview_portfolio.rda")
+      file.path(input_path_project_specific, "inputs", "overview_portfolio.rda")
     )
 
   #### Calculate unweighted company level PACTA results-------------------------
@@ -322,7 +322,7 @@ run_prep_calculation_loans <- function(data_path_project_specific,
 
   loans_results_company %>%
     saveRDS(
-      file.path(data_path_project_specific, "inputs", "Loans_results_company.rda")
+      file.path(input_path_project_specific, "inputs", "Loans_results_company.rda")
     )
 
 }

--- a/R/run_prep_calculation_loans.R
+++ b/R/run_prep_calculation_loans.R
@@ -18,93 +18,89 @@ run_prep_calculation_loans <- function(input_path_project_specific,
 
   #### Load input data sets-----------------------------------------------------
   # raw loan book
-  validate_file_exists(file.path(input_path_project_specific, "inputs", paste0("raw_loanbook.csv")))
-  loanbook <- readr::read_csv(
-    file.path(input_path_project_specific, "inputs", paste0("raw_loanbook.csv")),
-    col_types = readr::cols(
-      id_loan = "c",
-      id_direct_loantaker = "c",
-      name_direct_loantaker = "c",
-      id_intermediate_parent_1 = "c",
-      name_intermediate_parent_1 = "c",
-      id_ultimate_parent = "c",
-      name_ultimate_parent = "c",
-      loan_size_outstanding = "d",
-      loan_size_outstanding_currency = "c",
-      loan_size_credit_limit = "d",
-      loan_size_credit_limit_currency = "c",
-      sector_classification_system = "c",
-      sector_classification_input_type = "c",
-      sector_classification_direct_loantaker = "c",
-      fi_type = "c",
-      flag_project_finance_loan = "c",
-      name_project = "c",
-      lei_direct_loantaker = "c",
-      isin_direct_loantaker = "c"
+  loanbook <- validate_file_exists(file.path(input_path_project_specific, "inputs", paste0("raw_loanbook.csv"))) %>%
+    readr::read_csv(
+      col_types = readr::cols(
+        id_loan = "c",
+        id_direct_loantaker = "c",
+        name_direct_loantaker = "c",
+        id_intermediate_parent_1 = "c",
+        name_intermediate_parent_1 = "c",
+        id_ultimate_parent = "c",
+        name_ultimate_parent = "c",
+        loan_size_outstanding = "d",
+        loan_size_outstanding_currency = "c",
+        loan_size_credit_limit = "d",
+        loan_size_credit_limit_currency = "c",
+        sector_classification_system = "c",
+        sector_classification_input_type = "c",
+        sector_classification_direct_loantaker = "c",
+        fi_type = "c",
+        flag_project_finance_loan = "c",
+        name_project = "c",
+        lei_direct_loantaker = "c",
+        isin_direct_loantaker = "c"
+      )
     )
-  )
 
   # matched loan book
-  validate_file_exists(file.path(input_path_project_specific, "inputs", "matched_loan_book.csv"))
-  matched  <- readr::read_csv(
-    file.path(input_path_project_specific, "inputs", "matched_loan_book.csv"),
-    col_types = readr::cols_only(
-      id_loan = "c",
-      id_direct_loantaker = "c",
-      name_direct_loantaker = "c",
-      id_intermediate_parent_1 = "c",
-      name_intermediate_parent_1 = "c",
-      id_ultimate_parent = "c",
-      name_ultimate_parent = "c",
-      loan_size_outstanding = "d",
-      loan_size_outstanding_currency = "c",
-      loan_size_credit_limit = "d",
-      loan_size_credit_limit_currency = "c",
-      sector_classification_system = "c",
-      sector_classification_input_type = "c",
-      sector_classification_direct_loantaker = "c",
-      fi_type = "c",
-      flag_project_finance_loan = "c",
-      name_project = "c",
-      lei_direct_loantaker = "c",
-      isin_direct_loantaker = "c",
-      id_2dii = "c",
-      level = "c",
-      sector = "c",
-      sector_ald = "c",
-      name = "c",
-      name_ald = "c",
-      score = "d",
-      source = "c",
-      borderline = "l"
+  matched <- validate_file_exists(file.path(input_path_project_specific, "inputs", "matched_loan_book.csv")) %>%
+    readr::read_csv(
+      col_types = readr::cols_only(
+        id_loan = "c",
+        id_direct_loantaker = "c",
+        name_direct_loantaker = "c",
+        id_intermediate_parent_1 = "c",
+        name_intermediate_parent_1 = "c",
+        id_ultimate_parent = "c",
+        name_ultimate_parent = "c",
+        loan_size_outstanding = "d",
+        loan_size_outstanding_currency = "c",
+        loan_size_credit_limit = "d",
+        loan_size_credit_limit_currency = "c",
+        sector_classification_system = "c",
+        sector_classification_input_type = "c",
+        sector_classification_direct_loantaker = "c",
+        fi_type = "c",
+        flag_project_finance_loan = "c",
+        name_project = "c",
+        lei_direct_loantaker = "c",
+        isin_direct_loantaker = "c",
+        id_2dii = "c",
+        level = "c",
+        sector = "c",
+        sector_ald = "c",
+        name = "c",
+        name_ald = "c",
+        score = "d",
+        source = "c",
+        borderline = "l"
+      )
     )
-  )
 
   # region iso mapping
   regions <- r2dii.data::region_isos
 
   # Production forecast data
-  validate_file_exists(file.path(input_path_project_agnostic, "2021-07-15_AR_2020Q4_PACTA-Data (3).xlsx"))
-  production_forecast_data <- readxl::read_xlsx(
-    file.path(input_path_project_agnostic, "2021-07-15_AR_2020Q4_PACTA-Data (3).xlsx"),
+  production_forecast_data <- validate_file_exists(file.path(input_path_project_agnostic, "2021-07-15_AR_2020Q4_PACTA-Data (3).xlsx")) %>%
+    readxl::read_xlsx(
     sheet = "Company Indicators - PACTA"
   )
 
   # Scenario data - market share
-  validate_file_exists(file.path(input_path_project_agnostic, "scenario_2020.csv"))
-  scenario_data_market_share <- readr::read_csv(
-    file.path(input_path_project_agnostic, glue::glue("scenario_2020.csv")),
-    col_types = readr::cols(
-      scenario_source = "c",
-      scenario = "c",
-      sector = "c",
-      technology = "c",
-      region = "c",
-      year = "d",
-      tmsr = "d",
-      smsp = "d"
+  scenario_data_market_share <- validate_file_exists(file.path(input_path_project_agnostic, "scenario_2020.csv")) %>%
+    readr::read_csv(
+      col_types = readr::cols(
+        scenario_source = "c",
+        scenario = "c",
+        sector = "c",
+        technology = "c",
+        region = "c",
+        year = "d",
+        tmsr = "d",
+        smsp = "d"
+      )
     )
-  )
 
   #### Wrangle and prepare data-------------------------------------------------
   # ADO 2690 - remove rows with negative loan values (not allowed in P4B)

--- a/R/run_stress_test.R
+++ b/R/run_stress_test.R
@@ -12,6 +12,7 @@
 #'   data.
 #' @param input_path_project_agnostic String holding path to project agnostic
 #'   data.
+#' @param output_path String holding path to which output files are written.
 #' @param lgd_senior_claims Numeric, holding the loss given default for senior
 #'   claims, for accepted value range check `lgd_senior_claims_range_lookup`.
 #' @param lgd_subordinated_claims Numeric, holding the loss given default for
@@ -40,6 +41,7 @@
 run_stress_test <- function(asset_type,
                             input_path_project_specific,
                             input_path_project_agnostic,
+                            output_path,
                             lgd_senior_claims = 0.45,
                             lgd_subordinated_claims = 0.75,
                             terminal_value = 0,
@@ -73,7 +75,7 @@ run_stress_test <- function(asset_type,
     calculation_level = calculation_level_lookup,
     sensitivity_analysis_vars = names(args_list)[!names(args_list) %in% path_vars_lookup],
     iter_var = iter_var,
-    results_path = file.path(input_path_project_specific, "outputs")
+    output_path = output_path
   )
 
   cat("-- Exported results to designated output path. \n")
@@ -91,6 +93,7 @@ run_stress_test_iteration <- function(n, args_tibble) {
     dplyr::slice(n)
 
   arg_list_row <- arg_tibble_row %>%
+    dplyr::select(-output_path) %>%
     as.list()
 
   arg_tibble_row <- arg_tibble_row %>%

--- a/R/run_stress_test.R
+++ b/R/run_stress_test.R
@@ -8,9 +8,9 @@
 #'
 #' @param asset_type String holding asset_type, for allowed value compare
 #'   `asset_types_lookup`.
-#' @param data_path_project_specific String holding path to project specific
+#' @param input_path_project_specific String holding path to project specific
 #'   data.
-#' @param data_path_project_agnostic String holding path to project agnostic
+#' @param input_path_project_agnostic String holding path to project agnostic
 #'   data.
 #' @param lgd_senior_claims Numeric, holding the loss given default for senior
 #'   claims, for accepted value range check `lgd_senior_claims_range_lookup`.
@@ -38,8 +38,8 @@
 #' @return NULL
 #' @export
 run_stress_test <- function(asset_type,
-                            data_path_project_specific,
-                            data_path_project_agnostic,
+                            input_path_project_specific,
+                            input_path_project_agnostic,
                             lgd_senior_claims = 0.45,
                             lgd_subordinated_claims = 0.75,
                             terminal_value = 0,
@@ -73,7 +73,7 @@ run_stress_test <- function(asset_type,
     calculation_level = calculation_level_lookup,
     sensitivity_analysis_vars = names(args_list)[!names(args_list) %in% path_vars_lookup],
     iter_var = iter_var,
-    results_path = file.path(data_path_project_specific, "outputs")
+    results_path = file.path(input_path_project_specific, "outputs")
   )
 
   cat("-- Exported results to designated output path. \n")
@@ -110,8 +110,8 @@ run_stress_test_iteration <- function(n, args_tibble) {
 #'
 #' @return A list of stress test results.
 run_stress_test_impl <- function(asset_type,
-                                 data_path_project_specific,
-                                 data_path_project_agnostic,
+                                 input_path_project_specific,
+                                 input_path_project_agnostic,
                                  lgd_senior_claims,
                                  lgd_subordinated_claims,
                                  terminal_value,
@@ -166,7 +166,7 @@ run_stress_test_impl <- function(asset_type,
     scenarios_filter = scenarios_filter,
     equity_market_filter = equity_market_filter_lookup,
     term = term,
-    path = data_path_project_specific
+    path = input_path_project_specific
   )
 
   project_specific_data_list <- pacta_based_data$data_list
@@ -178,7 +178,7 @@ run_stress_test_impl <- function(asset_type,
     company_exclusion = company_exclusion,
     scenario_geography_filter = scenario_geography_filter,
     asset_type = asset_type,
-    path = data_path_project_agnostic
+    path = input_path_project_agnostic
   )
 
   input_data_list <- c(project_specific_data_list, project_agnostic_data_list) %>%

--- a/R/utils.R
+++ b/R/utils.R
@@ -68,11 +68,11 @@ path_dropbox_2dii <- function(...) {
 #'
 #' @param path Character vector indicating the directory of a file.
 #'
-#' @return NULL
+#' @return String holding provided `path`.
 #'
 #' @export
 validate_file_exists <- function(path) {
-  valid_file_path <- file.exists(file.path(path))
+  valid_file_path <- file.exists(path)
 
   if (!valid_file_path) {
     rlang::abort(c(
@@ -81,7 +81,7 @@ validate_file_exists <- function(path) {
       i = "Did you set path to data correctly?."
     ))
   }
-  invisible()
+  invisible(path)
 }
 
 #' Validate that a data frame contains expected columns

--- a/R/utils.R
+++ b/R/utils.R
@@ -76,7 +76,7 @@ validate_file_exists <- function(path) {
 
   if (!valid_file_path) {
     rlang::abort(c(
-      "Detected invalid file path.",
+      "Path must point to an existing file.",
       x = glue::glue("Invalid file path: {file.path(path)}."),
       i = "Did you set path to data correctly?."
     ))
@@ -105,7 +105,7 @@ validate_data_has_expected_cols <- function(data,
   if (!data_has_expected_columns) {
     affected_cols <- glue::glue_collapse(sort(setdiff(expected_columns, names(data))), sep = ", ")
     rlang::abort(c(
-      "Detected missing columns on data set.",
+      "Must include expected columns in data set.",
       x = glue::glue("Missing columns: {affected_cols}."),
       i = "Please check that data have expected columns."
     ))

--- a/R/write_results.R
+++ b/R/write_results.R
@@ -13,23 +13,30 @@
 #' @param sensitivity_analysis_vars String vector holding names of iteration
 #'   arguments.
 #' @param iter_var String holding name of iteration variable.
-#' @param results_path String holding path to output dir.
+#' @param output_path String holding path to output dir.
 #'
 #' @return NULL
 write_stress_test_results <- function(results, expected_loss,
                                       annual_pd_changes, overall_pd_changes,
                                       asset_type, calculation_level,
                                       sensitivity_analysis_vars, iter_var,
-                                      results_path) {
+                                      output_path) {
 
-  if (!dir.exists(results_path)) {
-    dir.create(results_path)
+  if (!dir.exists(output_path)) {
+    rlang::abort(
+      c(
+        "Argument output_path must point to an existing directory.",
+        x = glue::glue("Invalid file path: {output_path}."),
+        i = "Did you set output_path correctly?."
+      )
+    )
   }
 
   sensitivity_analysis_vars <- paste0(sensitivity_analysis_vars, "_arg")
+
   results %>%
     write_results_new(
-      path_to_results = results_path,
+      path_to_results = output_path,
       asset_type = asset_type,
       level = calculation_level,
       file_type = "csv",
@@ -65,7 +72,7 @@ write_stress_test_results <- function(results, expected_loss,
       )
     ) %>%
     readr::write_csv(file.path(
-      results_path,
+      output_path,
       paste0("stress_test_results_", asset_type, "_comp_el_", iter_var,".csv")
     ))
 
@@ -97,7 +104,7 @@ write_stress_test_results <- function(results, expected_loss,
       )
     ) %>%
     readr::write_csv(file.path(
-      results_path,
+      output_path,
       paste0("stress_test_results_", asset_type, "_sector_pd_changes_annual_", iter_var, ".csv")
     ))
 
@@ -129,7 +136,7 @@ write_stress_test_results <- function(results, expected_loss,
       )
     ) %>%
     readr::write_csv(file.path(
-      results_path,
+      output_path,
       paste0("stress_test_results_", asset_type, "_sector_pd_changes_overall_", iter_var, ".csv")
     ))
 }

--- a/README.Rmd
+++ b/README.Rmd
@@ -40,7 +40,8 @@ library(r2dii.climate.stress.test)
 ```{r, results='hide', message=FALSE, warning=FALSE, eval=FALSE}
 run_prep_calculation_loans(
   input_path_project_specific = "/path/to/specific/data",
-  input_path_project_agnostic = "/path/to/agnostic/data"
+  input_path_project_agnostic = "/path/to/agnostic/data",
+  data_prep_output_path = "/path/to/specific/data"
 )
 
 ```

--- a/README.Rmd
+++ b/README.Rmd
@@ -37,7 +37,7 @@ library(r2dii.climate.stress.test)
 ```
 
 * Stress tests for corporate loans require a preparatory step for input data preparation for initial application of stress testing on a loan book
-```{r, results='hide', message=FALSE, warning=FALSE, eval=FALSE}
+```{r, eval=FALSE}
 run_prep_calculation_loans(
   input_path_project_specific = "/path/to/specific/data",
   input_path_project_agnostic = "/path/to/agnostic/data",
@@ -47,7 +47,7 @@ run_prep_calculation_loans(
 ```
 
 * Run climate stress tests
-```{r, results='hide', message=FALSE, warning=FALSE, eval=FALSE}
+```{r, eval=FALSE}
 ## run stress testing for assets of type corporate loans using default parameters
 run_stress_test(
   asset_type = "loans",

--- a/README.Rmd
+++ b/README.Rmd
@@ -36,6 +36,15 @@ devtools::install_github("2DegreesInvesting/r2dii.climate.stress.test")
 library(r2dii.climate.stress.test)
 ```
 
+* Stress tests for corporate loans require a preparatory step for input data preparation for initial application of stress testing on a loan book
+```{r, results='hide', message=FALSE, warning=FALSE, eval=FALSE}
+run_prep_calculation_loans(
+  data_path_project_specific = "/path/to/specific/data",
+  data_path_project_agnostic = "/path/to/agnostic/data"
+)
+
+```
+
 * Run climate stress tests
 ```{r, results='hide', message=FALSE, warning=FALSE, eval=FALSE}
 ## run stress testing for assets of type corporate loans using default parameters
@@ -56,18 +65,9 @@ run_stress_test(
 ```
 
 ## Details
-### Prepare input data
-Stress tests for corporate loans require an additional step for input data preparation for initial application of stress testing on a loanbook.
-```{r, results='hide', message=FALSE, warning=FALSE, eval=FALSE}
-run_prep_calculation_loans(
-  data_path_project_specific = "/path/to/specific/data",
-  data_path_project_agnostic = "/path/to/agnostic/data"
-)
 
-```
-
-### Look up valid ranges of model parameters
-You can look up allowed values of model parameters as such:
+### Look up valid ranges of input arguments
+You can look up allowed values of input arguments as such:
 ```{r}
 lgd_senior_claims_range_lookup
 
@@ -88,4 +88,4 @@ term_range_lookup
 credit_type_lookup
 ```
 
-[Get started](https://2degreesinvesting.github.io/r2dii.climate.stress.test/articles/).
+[Further Information](https://2degreesinvesting.github.io/r2dii.climate.stress.test/articles/).

--- a/README.Rmd
+++ b/README.Rmd
@@ -51,7 +51,8 @@ run_prep_calculation_loans(
 run_stress_test(
   asset_type = "loans",
   input_path_project_specific = "/path/to/specific/data",
-  input_path_project_agnostic = "/path/to/agnostic/data"
+  input_path_project_agnostic = "/path/to/agnostic/data",
+  output_path = "/path/to/output/directory"
 )
 
 ## run stress testing for asset of type corporate loans using various risk_free_rates to analyse sensitivities
@@ -59,6 +60,7 @@ run_stress_test(
   asset_type = "loans",
   input_path_project_specific = "/path/to/specific/data",
   input_path_project_agnostic = "/path/to/agnostic/data",
+  output_path = "/path/to/output/directory",
   risk_free_rate = c(0.01, 0.03)
 )
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -39,8 +39,8 @@ library(r2dii.climate.stress.test)
 * Stress tests for corporate loans require a preparatory step for input data preparation for initial application of stress testing on a loan book
 ```{r, results='hide', message=FALSE, warning=FALSE, eval=FALSE}
 run_prep_calculation_loans(
-  data_path_project_specific = "/path/to/specific/data",
-  data_path_project_agnostic = "/path/to/agnostic/data"
+  input_path_project_specific = "/path/to/specific/data",
+  input_path_project_agnostic = "/path/to/agnostic/data"
 )
 
 ```
@@ -50,15 +50,15 @@ run_prep_calculation_loans(
 ## run stress testing for assets of type corporate loans using default parameters
 run_stress_test(
   asset_type = "loans",
-  data_path_project_specific = "/path/to/specific/data",
-  data_path_project_agnostic = "/path/to/agnostic/data"
+  input_path_project_specific = "/path/to/specific/data",
+  input_path_project_agnostic = "/path/to/agnostic/data"
 )
 
 ## run stress testing for asset of type corporate loans using various risk_free_rates to analyse sensitivities
 run_stress_test(
   asset_type = "loans",
-  data_path_project_specific = "/path/to/specific/data",
-  data_path_project_agnostic = "/path/to/agnostic/data",
+  input_path_project_specific = "/path/to/specific/data",
+  input_path_project_agnostic = "/path/to/agnostic/data",
   risk_free_rate = c(0.01, 0.03)
 )
 

--- a/README.md
+++ b/README.md
@@ -34,44 +34,38 @@ devtools::install_github("2DegreesInvesting/r2dii.climate.stress.test")
 
 ## Example
 
-  - Use `library()` to attach the package
-
-<!-- end list -->
+-   Use `library()` to attach the package
 
 ``` r
 library(r2dii.climate.stress.test)
 ```
 
-  - Stress tests for corporate loans require a preparatory step for
+-   Stress tests for corporate loans require a preparatory step for
     input data preparation for initial application of stress testing on
     a loan book
 
-<!-- end list -->
-
 ``` r
 run_prep_calculation_loans(
-  data_path_project_specific = "/path/to/specific/data",
-  data_path_project_agnostic = "/path/to/agnostic/data"
+  input_path_project_specific = "/path/to/specific/data",
+  input_path_project_agnostic = "/path/to/agnostic/data"
 )
 ```
 
-  - Run climate stress tests
-
-<!-- end list -->
+-   Run climate stress tests
 
 ``` r
 ## run stress testing for assets of type corporate loans using default parameters
 run_stress_test(
   asset_type = "loans",
-  data_path_project_specific = "/path/to/specific/data",
-  data_path_project_agnostic = "/path/to/agnostic/data"
+  input_path_project_specific = "/path/to/specific/data",
+  input_path_project_agnostic = "/path/to/agnostic/data"
 )
 
 ## run stress testing for asset of type corporate loans using various risk_free_rates to analyse sensitivities
 run_stress_test(
   asset_type = "loans",
-  data_path_project_specific = "/path/to/specific/data",
-  data_path_project_agnostic = "/path/to/agnostic/data",
+  input_path_project_specific = "/path/to/specific/data",
+  input_path_project_agnostic = "/path/to/agnostic/data",
   risk_free_rate = c(0.01, 0.03)
 )
 ```

--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ library(r2dii.climate.stress.test)
 ``` r
 run_prep_calculation_loans(
   input_path_project_specific = "/path/to/specific/data",
-  input_path_project_agnostic = "/path/to/agnostic/data"
+  input_path_project_agnostic = "/path/to/agnostic/data",
+  data_prep_output_path = "/path/to/specific/data"
 )
 ```
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,8 @@ run_prep_calculation_loans(
 run_stress_test(
   asset_type = "loans",
   input_path_project_specific = "/path/to/specific/data",
-  input_path_project_agnostic = "/path/to/agnostic/data"
+  input_path_project_agnostic = "/path/to/agnostic/data",
+  output_path = "/path/to/output/directory"
 )
 
 ## run stress testing for asset of type corporate loans using various risk_free_rates to analyse sensitivities
@@ -66,6 +67,7 @@ run_stress_test(
   asset_type = "loans",
   input_path_project_specific = "/path/to/specific/data",
   input_path_project_agnostic = "/path/to/agnostic/data",
+  output_path = "/path/to/output/directory",
   risk_free_rate = c(0.01, 0.03)
 )
 ```

--- a/README.md
+++ b/README.md
@@ -34,13 +34,30 @@ devtools::install_github("2DegreesInvesting/r2dii.climate.stress.test")
 
 ## Example
 
--   Use `library()` to attach the package
+  - Use `library()` to attach the package
+
+<!-- end list -->
 
 ``` r
 library(r2dii.climate.stress.test)
 ```
 
--   Run climate stress tests
+  - Stress tests for corporate loans require a preparatory step for
+    input data preparation for initial application of stress testing on
+    a loan book
+
+<!-- end list -->
+
+``` r
+run_prep_calculation_loans(
+  data_path_project_specific = "/path/to/specific/data",
+  data_path_project_agnostic = "/path/to/agnostic/data"
+)
+```
+
+  - Run climate stress tests
+
+<!-- end list -->
 
 ``` r
 ## run stress testing for assets of type corporate loans using default parameters
@@ -61,22 +78,9 @@ run_stress_test(
 
 ## Details
 
-### Prepare input data
+### Look up valid ranges of input arguments
 
-Stress tests for corporate loans require an additional step for input
-data preparation for initial application of stress testing on a
-loanbook.
-
-``` r
-run_prep_calculation_loans(
-  data_path_project_specific = "/path/to/specific/data",
-  data_path_project_agnostic = "/path/to/agnostic/data"
-)
-```
-
-### Look up valid ranges of model parameters
-
-You can look up allowed values of model parameters as such:
+You can look up allowed values of input arguments as such:
 
 ``` r
 lgd_senior_claims_range_lookup
@@ -107,5 +111,5 @@ credit_type_lookup
 #> [1] "outstanding"  "credit_limit"
 ```
 
-[Get
-started](https://2degreesinvesting.github.io/r2dii.climate.stress.test/articles/).
+[Further
+Information](https://2degreesinvesting.github.io/r2dii.climate.stress.test/articles/).

--- a/man/run_prep_calculation_loans.Rd
+++ b/man/run_prep_calculation_loans.Rd
@@ -7,6 +7,7 @@
 run_prep_calculation_loans(
   input_path_project_specific,
   input_path_project_agnostic,
+  data_prep_output_path,
   credit_type = "outstanding"
 )
 }
@@ -16,6 +17,12 @@ data.}
 
 \item{input_path_project_agnostic}{String holding path to project agnostic
 data.}
+
+\item{data_prep_output_path}{Path where results are written.
+NOTE: This is a workflow that is needed exclusively in preparation of
+\code{\link[=run_stress_test]{run_stress_test()}} for loan books. It creates input data for the stress
+test. A recommended setting is to set data_prep_output_path to to the same
+path as \code{input_path_project_specific}.}
 
 \item{credit_type}{Type of credit. For accepted values please compare
 \code{credit_type_lookup}.}

--- a/man/run_prep_calculation_loans.Rd
+++ b/man/run_prep_calculation_loans.Rd
@@ -5,16 +5,16 @@
 \title{Run stress testing data preparation for loans}
 \usage{
 run_prep_calculation_loans(
-  data_path_project_specific,
-  data_path_project_agnostic,
+  input_path_project_specific,
+  input_path_project_agnostic,
   credit_type = "outstanding"
 )
 }
 \arguments{
-\item{data_path_project_specific}{String holding path to project specific
+\item{input_path_project_specific}{String holding path to project specific
 data.}
 
-\item{data_path_project_agnostic}{String holding path to project agnostic
+\item{input_path_project_agnostic}{String holding path to project agnostic
 data.}
 
 \item{credit_type}{Type of credit. For accepted values please compare

--- a/man/run_prep_calculation_loans.Rd
+++ b/man/run_prep_calculation_loans.Rd
@@ -21,7 +21,7 @@ data.}
 \item{data_prep_output_path}{Path where results are written.
 NOTE: This is a workflow that is needed exclusively in preparation of
 \code{\link[=run_stress_test]{run_stress_test()}} for loan books. It creates input data for the stress
-test. A recommended setting is to set data_prep_output_path to to the same
+test. A recommended setting is to set \code{data_prep_output_path} to to the same
 path as \code{input_path_project_specific}.}
 
 \item{credit_type}{Type of credit. For accepted values please compare

--- a/man/run_stress_test.Rd
+++ b/man/run_stress_test.Rd
@@ -6,8 +6,8 @@
 \usage{
 run_stress_test(
   asset_type,
-  data_path_project_specific,
-  data_path_project_agnostic,
+  input_path_project_specific,
+  input_path_project_agnostic,
   lgd_senior_claims = 0.45,
   lgd_subordinated_claims = 0.75,
   terminal_value = 0,
@@ -23,10 +23,10 @@ run_stress_test(
 \item{asset_type}{String holding asset_type, for allowed value compare
 \code{asset_types_lookup}.}
 
-\item{data_path_project_specific}{String holding path to project specific
+\item{input_path_project_specific}{String holding path to project specific
 data.}
 
-\item{data_path_project_agnostic}{String holding path to project agnostic
+\item{input_path_project_agnostic}{String holding path to project agnostic
 data.}
 
 \item{lgd_senior_claims}{Numeric, holding the loss given default for senior

--- a/man/run_stress_test.Rd
+++ b/man/run_stress_test.Rd
@@ -8,6 +8,7 @@ run_stress_test(
   asset_type,
   input_path_project_specific,
   input_path_project_agnostic,
+  output_path,
   lgd_senior_claims = 0.45,
   lgd_subordinated_claims = 0.75,
   terminal_value = 0,
@@ -28,6 +29,8 @@ data.}
 
 \item{input_path_project_agnostic}{String holding path to project agnostic
 data.}
+
+\item{output_path}{String holding path to which output files are written.}
 
 \item{lgd_senior_claims}{Numeric, holding the loss given default for senior
 claims, for accepted value range check \code{lgd_senior_claims_range_lookup}.}

--- a/man/run_stress_test_impl.Rd
+++ b/man/run_stress_test_impl.Rd
@@ -6,8 +6,8 @@
 \usage{
 run_stress_test_impl(
   asset_type,
-  data_path_project_specific,
-  data_path_project_agnostic,
+  input_path_project_specific,
+  input_path_project_agnostic,
   lgd_senior_claims,
   lgd_subordinated_claims,
   terminal_value,
@@ -23,10 +23,10 @@ run_stress_test_impl(
 \item{asset_type}{String holding asset_type, for allowed value compare
 \code{asset_types_lookup}.}
 
-\item{data_path_project_specific}{String holding path to project specific
+\item{input_path_project_specific}{String holding path to project specific
 data.}
 
-\item{data_path_project_agnostic}{String holding path to project agnostic
+\item{input_path_project_agnostic}{String holding path to project agnostic
 data.}
 
 \item{lgd_senior_claims}{Numeric, holding the loss given default for senior

--- a/man/validate_file_exists.Rd
+++ b/man/validate_file_exists.Rd
@@ -9,6 +9,9 @@ validate_file_exists(path)
 \arguments{
 \item{path}{Character vector indicating the directory of a file.}
 }
+\value{
+String holding provided \code{path}.
+}
 \description{
 Before performing an operation on a file assumed to be found in a given
 directory, validate this file exists and give indicative error if not.

--- a/man/write_stress_test_results.Rd
+++ b/man/write_stress_test_results.Rd
@@ -13,7 +13,7 @@ write_stress_test_results(
   calculation_level,
   sensitivity_analysis_vars,
   iter_var,
-  results_path
+  output_path
 )
 }
 \arguments{
@@ -36,7 +36,7 @@ arguments.}
 
 \item{iter_var}{String holding name of iteration variable.}
 
-\item{results_path}{String holding path to output dir.}
+\item{output_path}{String holding path to output dir.}
 }
 \description{
 Stress test results are wrangled and exported to the output dir.

--- a/nonstandard/QA_scripts/change_check_cb.R
+++ b/nonstandard/QA_scripts/change_check_cb.R
@@ -60,7 +60,8 @@ devtools::load_all()
 run_stress_test(
   asset_type = "bonds",
   input_path_project_agnostic = get_st_data_path(),
-  input_path_project_specific = get_st_data_path("ST_PROJECT_FOLDER")
+  input_path_project_specific = get_st_data_path("ST_PROJECT_FOLDER_INPUT"),
+  output_path = get_st_data_path("ST_PROJECT_FOLDER_OUTPUT")
 )
 
 ### 2. run the following lines to obtain results
@@ -71,7 +72,8 @@ devtools::load_all()
 run_stress_test(
   asset_type = "bonds",
   input_path_project_agnostic = get_st_data_path(),
-  input_path_project_specific = get_st_data_path("ST_PROJECT_FOLDER")
+  input_path_project_specific = get_st_data_path("ST_PROJECT_FOLDER_INPUT"),
+  output_path = get_st_data_path("ST_PROJECT_FOLDER_OUTPUT")
 )
 
 ### 4. run the following lines to run script or equity and bonds and obtain results
@@ -118,7 +120,8 @@ devtools::load_all()
 run_stress_test(
   asset_type = "bonds",
   input_path_project_agnostic = get_st_data_path(),
-  input_path_project_specific = get_st_data_path("ST_PROJECT_FOLDER"),
+  input_path_project_specific = get_st_data_path("ST_PROJECT_FOLDER_INPUT"),
+  output_path = get_st_data_path("ST_PROJECT_FOLDER_OUTPUT"),
   shock_year = c(2025, 2030, 2033)
 )
 
@@ -130,7 +133,8 @@ devtools::load_all()
 run_stress_test(
   asset_type = "bonds",
   input_path_project_agnostic = get_st_data_path(),
-  input_path_project_specific = get_st_data_path("ST_PROJECT_FOLDER"),
+  input_path_project_specific = get_st_data_path("ST_PROJECT_FOLDER_INPUT"),
+  output_path = get_st_data_path("ST_PROJECT_FOLDER_OUTPUT"),
   shock_year = c(2025, 2030, 2033)
 )
 

--- a/nonstandard/QA_scripts/change_check_cb.R
+++ b/nonstandard/QA_scripts/change_check_cb.R
@@ -89,7 +89,7 @@ check
 
 # defining some functions
 import_asset_results <- function() {
-  results_path <- file.path(get_st_data_path("ST_PROJECT_FOLDER"), "outputs")
+  results_path <- get_st_data_path("ST_PROJECT_FOLDER_OUTPUT")
 
   bonds_results_company <- readr::read_csv(file.path(results_path, "stress_test_results_bonds_comp_shock_year.csv"))
   bonds_results_port <- readr::read_csv(file.path(results_path, "stress_test_results_bonds_port_shock_year.csv"))

--- a/nonstandard/QA_scripts/change_check_cb.R
+++ b/nonstandard/QA_scripts/change_check_cb.R
@@ -4,7 +4,7 @@
 
 # defining some functions
 import_asset_results <- function() {
-  results_path <- file.path(get_st_data_path("ST_PROJECT_FOLDER"), "outputs")
+  results_path <- get_st_data_path("ST_PROJECT_FOLDER_OUTPUT")
 
   bonds_results_company <- readr::read_csv(file.path(results_path, "stress_test_results_bonds_comp_standard.csv"))
   bonds_results_port <- readr::read_csv(file.path(results_path, "stress_test_results_bonds_port_standard.csv"))

--- a/nonstandard/QA_scripts/change_check_cb.R
+++ b/nonstandard/QA_scripts/change_check_cb.R
@@ -59,8 +59,8 @@ check_all_equal <- function(old_results, new_results) {
 devtools::load_all()
 run_stress_test(
   asset_type = "bonds",
-  data_path_project_agnostic = get_st_data_path(),
-  data_path_project_specific = get_st_data_path("ST_PROJECT_FOLDER")
+  input_path_project_agnostic = get_st_data_path(),
+  input_path_project_specific = get_st_data_path("ST_PROJECT_FOLDER")
 )
 
 ### 2. run the following lines to obtain results
@@ -70,8 +70,8 @@ old_results <- import_asset_results()
 devtools::load_all()
 run_stress_test(
   asset_type = "bonds",
-  data_path_project_agnostic = get_st_data_path(),
-  data_path_project_specific = get_st_data_path("ST_PROJECT_FOLDER")
+  input_path_project_agnostic = get_st_data_path(),
+  input_path_project_specific = get_st_data_path("ST_PROJECT_FOLDER")
 )
 
 ### 4. run the following lines to run script or equity and bonds and obtain results
@@ -117,8 +117,8 @@ import_asset_results <- function() {
 devtools::load_all()
 run_stress_test(
   asset_type = "bonds",
-  data_path_project_agnostic = get_st_data_path(),
-  data_path_project_specific = get_st_data_path("ST_PROJECT_FOLDER"),
+  input_path_project_agnostic = get_st_data_path(),
+  input_path_project_specific = get_st_data_path("ST_PROJECT_FOLDER"),
   shock_year = c(2025, 2030, 2033)
 )
 
@@ -129,8 +129,8 @@ old_results <- import_asset_results()
 devtools::load_all()
 run_stress_test(
   asset_type = "bonds",
-  data_path_project_agnostic = get_st_data_path(),
-  data_path_project_specific = get_st_data_path("ST_PROJECT_FOLDER"),
+  input_path_project_agnostic = get_st_data_path(),
+  input_path_project_specific = get_st_data_path("ST_PROJECT_FOLDER"),
   shock_year = c(2025, 2030, 2033)
 )
 

--- a/nonstandard/QA_scripts/change_check_cl.R
+++ b/nonstandard/QA_scripts/change_check_cl.R
@@ -56,8 +56,9 @@ check_all_equal <- function(old_results, new_results) {
 ### 1. check out master branch of repo (or whichever branch you want to use as reference)
 devtools::load_all()
 run_stress_test(
-  asset_type = "loans", data_path_project_agnostic = get_st_data_path(),
-  data_path_project_specific = get_st_data_path("ST_PROJECT_FOLDER")
+  asset_type = "loans",
+  input_path_project_agnostic = get_st_data_path(),
+  input_path_project_specific = get_st_data_path("ST_PROJECT_FOLDER")
 )
 
 ### 2. run the following lines to obtain results
@@ -67,8 +68,8 @@ old_results <- import_asset_results()
 devtools::load_all()
 run_stress_test(
   asset_type = "loans",
-  data_path_project_agnostic = get_st_data_path(),
-  data_path_project_specific = get_st_data_path("ST_PROJECT_FOLDER")
+  input_path_project_agnostic = get_st_data_path(),
+  input_path_project_specific = get_st_data_path("ST_PROJECT_FOLDER")
 )
 
 

--- a/nonstandard/QA_scripts/change_check_cl.R
+++ b/nonstandard/QA_scripts/change_check_cl.R
@@ -58,7 +58,8 @@ devtools::load_all()
 run_stress_test(
   asset_type = "loans",
   input_path_project_agnostic = get_st_data_path(),
-  input_path_project_specific = get_st_data_path("ST_PROJECT_FOLDER")
+  input_path_project_specific = get_st_data_path("ST_PROJECT_FOLDER_INPUT"),
+  output_path = get_st_data_path("ST_PROJECT_FOLDER_OUTPUT")
 )
 
 ### 2. run the following lines to obtain results
@@ -69,7 +70,8 @@ devtools::load_all()
 run_stress_test(
   asset_type = "loans",
   input_path_project_agnostic = get_st_data_path(),
-  input_path_project_specific = get_st_data_path("ST_PROJECT_FOLDER")
+  input_path_project_specific = get_st_data_path("ST_PROJECT_FOLDER_INPUT"),
+  output_path = get_st_data_path("ST_PROJECT_FOLDER_OUTPUT")
 )
 
 

--- a/nonstandard/QA_scripts/change_check_cl.R
+++ b/nonstandard/QA_scripts/change_check_cl.R
@@ -2,7 +2,7 @@
 
 # defining some functions
 import_asset_results <- function() {
-  results_path <- file.path(get_st_data_path("ST_PROJECT_FOLDER"), "outputs")
+  results_path <- get_st_data_path("ST_PROJECT_FOLDER_OUTPUT")
 
   loanbook_results_company <- readr::read_csv(file.path(results_path, "stress_test_results_loans_comp_standard.csv"))
   loanbook_results_port <- readr::read_csv(file.path(results_path, "stress_test_results_loans_port_standard.csv"))

--- a/nonstandard/QA_scripts/change_check_eq.R
+++ b/nonstandard/QA_scripts/change_check_eq.R
@@ -3,7 +3,7 @@
 # defining some functions
 import_asset_results <- function() {
 
-  results_path <- file.path(get_st_data_path("ST_PROJECT_FOLDER"), "outputs")
+  results_path <- get_st_data_path("ST_PROJECT_FOLDER_OUTPUT")
 
   equity_results_company <- readr::read_csv(file.path(results_path, "stress_test_results_equity_comp_standard.csv"))
   equity_results_port <- readr::read_csv(file.path(results_path, "stress_test_results_equity_port_standard.csv"))

--- a/nonstandard/QA_scripts/change_check_eq.R
+++ b/nonstandard/QA_scripts/change_check_eq.R
@@ -60,7 +60,8 @@ devtools::load_all()
 run_stress_test(
   asset_type = "equity",
   input_path_project_agnostic = get_st_data_path(),
-  input_path_project_specific = get_st_data_path("ST_PROJECT_FOLDER")
+  input_path_project_specific = get_st_data_path("ST_PROJECT_FOLDER_INPUT"),
+  output_path = get_st_data_path("ST_PROJECT_FOLDER_OUTPUT")
 )
 
 ### 2. run the following lines to obtain results
@@ -71,7 +72,8 @@ devtools::load_all()
 run_stress_test(
   asset_type = "equity",
   input_path_project_agnostic = get_st_data_path(),
-  input_path_project_specific = get_st_data_path("ST_PROJECT_FOLDER")
+  input_path_project_specific = get_st_data_path("ST_PROJECT_FOLDER_INPUT"),
+  output_path = get_st_data_path("ST_PROJECT_FOLDER_OUTPUT")
 )
 
 ### 4. run the following lines to run script or equity and bonds and obtain results

--- a/nonstandard/QA_scripts/change_check_eq.R
+++ b/nonstandard/QA_scripts/change_check_eq.R
@@ -59,8 +59,8 @@ check_all_equal <- function(old_results, new_results) {
 devtools::load_all()
 run_stress_test(
   asset_type = "equity",
-  data_path_project_agnostic = get_st_data_path(),
-  data_path_project_specific = get_st_data_path("ST_PROJECT_FOLDER")
+  input_path_project_agnostic = get_st_data_path(),
+  input_path_project_specific = get_st_data_path("ST_PROJECT_FOLDER")
 )
 
 ### 2. run the following lines to obtain results
@@ -70,8 +70,8 @@ old_results <- import_asset_results()
 devtools::load_all()
 run_stress_test(
   asset_type = "equity",
-  data_path_project_agnostic = get_st_data_path(),
-  data_path_project_specific = get_st_data_path("ST_PROJECT_FOLDER")
+  input_path_project_agnostic = get_st_data_path(),
+  input_path_project_specific = get_st_data_path("ST_PROJECT_FOLDER")
 )
 
 ### 4. run the following lines to run script or equity and bonds and obtain results

--- a/nonstandard/QA_scripts/qa_cb.R
+++ b/nonstandard/QA_scripts/qa_cb.R
@@ -19,8 +19,8 @@ function_paths <- c(
 source_all(function_paths)
 
 inputs_path <- get_st_data_path()
-results_path <- file.path(get_st_data_path("ST_PROJECT_FOLDER"), "outputs")
-graph_path <- file.path(get_st_data_path("ST_PROJECT_FOLDER"), "outputs", "graphs")
+results_path <- get_st_data_path("ST_PROJECT_FOLDER_OUTPUT")
+graph_path <- file.path(get_st_data_path("ST_PROJECT_FOLDER_OUTPUT"), "graphs")
 if (!fs::dir_exists(graph_path)) {fs::dir_create(graph_path)}
 
 cfg_st <- config::get(file = "st_project_settings.yml")

--- a/nonstandard/QA_scripts/qa_cl.R
+++ b/nonstandard/QA_scripts/qa_cl.R
@@ -19,8 +19,8 @@ function_paths <- c(
 source_all(function_paths)
 
 inputs_path <- get_st_data_path()
-results_path <- file.path(get_st_data_path("ST_PROJECT_FOLDER"), "outputs")
-graph_path <- file.path(get_st_data_path("ST_PROJECT_FOLDER"), "outputs", "graphs")
+results_path <- get_st_data_path("ST_PROJECT_FOLDER_OUTPUT")
+graph_path <- file.path(get_st_data_path("ST_PROJECT_FOLDER_OUTPUT"), "graphs")
 if (!fs::dir_exists(graph_path)) {fs::dir_create(graph_path)}
 
 cfg_st <- config::get(file = "st_project_settings.yml")

--- a/nonstandard/QA_scripts/qa_eq.R
+++ b/nonstandard/QA_scripts/qa_eq.R
@@ -19,8 +19,8 @@ function_paths <- c(
 source_all(function_paths)
 
 inputs_path <- get_st_data_path()
-results_path <- file.path(get_st_data_path("ST_PROJECT_FOLDER"), "outputs")
-graph_path <- file.path(get_st_data_path("ST_PROJECT_FOLDER"), "outputs", "graphs")
+results_path <- get_st_data_path("ST_PROJECT_FOLDER_OUTPUT")
+graph_path <- file.path(get_st_data_path("ST_PROJECT_FOLDER_OUTPUT"),"graphs")
 if (!fs::dir_exists(graph_path)) {fs::dir_create(graph_path)}
 
 cfg_st <- config::get(file = "st_project_settings.yml")

--- a/tests/testthat/test-run_stress_test.R
+++ b/tests/testthat/test-run_stress_test.R
@@ -8,8 +8,8 @@ test_that("output includes argument names with suffix '_arg'", {
 
 x <- suppressWarnings(capture.output(
   run_stress_test("bonds",
-    data_path_project_agnostic = get_st_data_path(),
-    data_path_project_specific = get_st_data_path("ST_PROJECT_FOLDER"),
+    input_path_project_agnostic = get_st_data_path(),
+    input_path_project_specific = get_st_data_path("ST_PROJECT_FOLDER"),
     term = 1:2
   )
 ))

--- a/tests/testthat/test-run_stress_test.R
+++ b/tests/testthat/test-run_stress_test.R
@@ -10,7 +10,7 @@ x <- suppressWarnings(capture.output(
   run_stress_test("bonds",
     input_path_project_agnostic = get_st_data_path(),
     input_path_project_specific = get_st_data_path("ST_PROJECT_FOLDER_INPUT"),
-    input_path_project_specific = get_st_data_path("ST_PROJECT_FOLDER_OUTPUT"),
+    output_path = get_st_data_path("ST_PROJECT_FOLDER_OUTPUT"),
     term = 1:2
   )
 ))

--- a/tests/testthat/test-run_stress_test.R
+++ b/tests/testthat/test-run_stress_test.R
@@ -9,7 +9,8 @@ test_that("output includes argument names with suffix '_arg'", {
 x <- suppressWarnings(capture.output(
   run_stress_test("bonds",
     input_path_project_agnostic = get_st_data_path(),
-    input_path_project_specific = get_st_data_path("ST_PROJECT_FOLDER"),
+    input_path_project_specific = get_st_data_path("ST_PROJECT_FOLDER_INPUT"),
+    input_path_project_specific = get_st_data_path("ST_PROJECT_FOLDER_OUTPUT"),
     term = 1:2
   )
 ))

--- a/tests/testthat/test-run_stress_test.R
+++ b/tests/testthat/test-run_stress_test.R
@@ -3,7 +3,7 @@ test_that("output includes argument names with suffix '_arg'", {
   skip_if_not(is_me)
 
   # Refresh
-  out_path <- fs::path(Sys.getenv("ST_PROJECT_FOLDER"), "outputs")
+  out_path <- fs::path(Sys.getenv("ST_PROJECT_FOLDER_OUTPUT"))
   if (fs::dir_exists(out_path)) fs::dir_delete(out_path)
 
 x <- suppressWarnings(capture.output(

--- a/vignettes/articles/prepare-loans-inputs.Rmd
+++ b/vignettes/articles/prepare-loans-inputs.Rmd
@@ -57,8 +57,8 @@ intermediate input files `Loans_results_company.rda` and `overview_portfolio.rda
 to the same input file directory.
 
 ```{r}
-run_prep_calculation_loans(data_path_project_specific = "/path/to/specific/data",
-                           data_path_project_agnostic = "/path/to/agnostic/data")
+run_prep_calculation_loans(input_path_project_specific = "/path/to/specific/data",
+                           input_path_project_agnostic = "/path/to/agnostic/data")
 ```
 
 Since the argument credit_type has a default value, it is not required to set it,
@@ -71,8 +71,8 @@ achieve this, instead of the previous command, simply run:
 
 ```{r}
 run_prep_calculation_loans(
-  data_path_project_specific = "/path/to/specific/data",
-  data_path_project_agnostic = "/path/to/agnostic/data",
+  input_path_project_specific = "/path/to/specific/data",
+  input_path_project_agnostic = "/path/to/agnostic/data",
   credit_type = "credit_limit"
 )
 ```

--- a/vignettes/articles/prepare-loans-inputs.Rmd
+++ b/vignettes/articles/prepare-loans-inputs.Rmd
@@ -46,19 +46,22 @@ minimal input from the user.
 The only argument that can be set is `credit_type`, which defaults to
 `"outstanding"` if the user passes no argument. View other options by running:
 
-```{r}
+```{r, eval=TRUE}
 credit_type_lookup
 ```
 
 If everything has been set up correctly, simply running the following command in
 R will read the raw and matched loan books from the indicated project-specific
 inputs directory, perform all calculations and wrangling required and write the
-intermediate input files `Loans_results_company.rda` and `overview_portfolio.rda`
-to the same input file directory.
+intermediate input files `Loans_results_company.rda` and
+`overview_portfolio.rda` to the data prep output directory. As these data will
+serve as inputs the the subsequent stresstest it is advisable to set
+`data_prep_output_path` to the same path as `input_path_project_specific`.
 
 ```{r}
 run_prep_calculation_loans(input_path_project_specific = "/path/to/specific/data",
-                           input_path_project_agnostic = "/path/to/agnostic/data")
+                           input_path_project_agnostic = "/path/to/agnostic/data",
+                           data_prep_output_path = "/path/to/specific/data")
 ```
 
 Since the argument credit_type has a default value, it is not required to set it,
@@ -73,6 +76,7 @@ achieve this, instead of the previous command, simply run:
 run_prep_calculation_loans(
   input_path_project_specific = "/path/to/specific/data",
   input_path_project_agnostic = "/path/to/agnostic/data",
+  data_prep_output_path = "/path/to/specific/data",
   credit_type = "credit_limit"
 )
 ```

--- a/vignettes/articles/run-stress-test.Rmd
+++ b/vignettes/articles/run-stress-test.Rmd
@@ -46,15 +46,15 @@ library(r2dii.climate.stress.test)
 In order to run a stress test for loans on one set of parameters, the user needs
 to pass exactly one value per input argument to the function
 `run_prep_calculation_loans()`. The only arguments that do not have a default
-value and must be set by the user are `asset_type`, `data_path_project_specific`
-and `data_path_project_agnostic`. In our case, we want to run the stress test
+value and must be set by the user are `asset_type`, `input_path_project_specific`
+and `input_path_project_agnostic`. In our case, we want to run the stress test
 for loans, so the easiest way to obtain results is by running:
 
 ```{r, eval = FALSE}
 run_stress_test(
   "loans",
-  data_path_project_specific = "/path/to/specific/data",
-  data_path_project_agnostic = "/path/to/agnostic/data"
+  input_path_project_specific = "/path/to/specific/data",
+  input_path_project_agnostic = "/path/to/agnostic/data"
 )
 ```
 
@@ -113,8 +113,8 @@ using:
 ```{r, eval = FALSE}
 run_stress_test(
   "loans",
-  data_path_project_specific = "/path/to/specific/data",
-  data_path_project_agnostic = "/path/to/agnostic/data",
+  input_path_project_specific = "/path/to/specific/data",
+  input_path_project_agnostic = "/path/to/agnostic/data",
   risk_free_rate = 0.01,
   shock_year = 2028
 )
@@ -148,8 +148,8 @@ for example, they can run the following:
 ```{r, eval = FALSE}
 run_stress_test(
   "loans",
-  data_path_project_specific = "/path/to/specific/data",
-  data_path_project_agnostic = "/path/to/agnostic/data",
+  input_path_project_specific = "/path/to/specific/data",
+  input_path_project_agnostic = "/path/to/agnostic/data",
   shock_year = c(2025, 2028, 2032, 2035)
 )
 ```
@@ -172,8 +172,8 @@ lower than the default, the following will work:
 ```{r, eval = FALSE}
 run_stress_test(
   "loans",
-  data_path_project_specific = "/path/to/specific/data",
-  data_path_project_agnostic = "/path/to/agnostic/data",
+  input_path_project_specific = "/path/to/specific/data",
+  input_path_project_agnostic = "/path/to/agnostic/data",
   risk_free_rate = 0.01,
   shock_year = c(2025, 2028, 2032, 2035)
 )

--- a/vignettes/articles/run-stress-test.Rmd
+++ b/vignettes/articles/run-stress-test.Rmd
@@ -54,7 +54,8 @@ for loans, so the easiest way to obtain results is by running:
 run_stress_test(
   "loans",
   input_path_project_specific = "/path/to/specific/data",
-  input_path_project_agnostic = "/path/to/agnostic/data"
+  input_path_project_agnostic = "/path/to/agnostic/data",
+  output_path = "/path/to/output/directory"
 )
 ```
 
@@ -115,6 +116,7 @@ run_stress_test(
   "loans",
   input_path_project_specific = "/path/to/specific/data",
   input_path_project_agnostic = "/path/to/agnostic/data",
+  output_path = "/path/to/output/directory",
   risk_free_rate = 0.01,
   shock_year = 2028
 )
@@ -150,6 +152,7 @@ run_stress_test(
   "loans",
   input_path_project_specific = "/path/to/specific/data",
   input_path_project_agnostic = "/path/to/agnostic/data",
+  output_path = "/path/to/output/directory",
   shock_year = c(2025, 2028, 2032, 2035)
 )
 ```
@@ -174,6 +177,7 @@ run_stress_test(
   "loans",
   input_path_project_specific = "/path/to/specific/data",
   input_path_project_agnostic = "/path/to/agnostic/data",
+  output_path = "/path/to/output/directory",
   risk_free_rate = 0.01,
   shock_year = c(2025, 2028, 2032, 2035)
 )


### PR DESCRIPTION
This PR go uncomfortably big, I am slightly sorry:

- included a sneaky refactoring to pipe in validate_file_exisits
- added output_path (run_stress_test) and data_prep_output_path (run_prep_loan_book)
- change checks passed
- new loan book input data were generated successfully

Some remarks:

- i wonder if to combine all 3 path in a list arg data_paths to make the interface leaner. However that would kind of make the fact that we write to an output dir less obvious, so not sure
- the output path for data_prep is the input path in the current approach. This might be confusing. I would rather not adapt our file approach here though, because that would be too much overhead to adapt all docs, after all in the hope that we can get rid of run_prep_loan_book at some point. Made it somewhat clear in the docs though
- it is becoming increasingly painful to change the interface due to the needed adjustments in readme, vignette, tests etc, we should keep an eye on that.