### PR TITLE
Update test to use paths correctly

### DIFF
--- a/tests/testthat/test-run_stress_test.R
+++ b/tests/testthat/test-run_stress_test.R
@@ -2,19 +2,20 @@ test_that("output includes argument names with suffix '_arg'", {
   is_me <- identical(path.expand("~"), "/home/mauro")
   skip_if_not(is_me)
 
-  # Refresh
-  out_path <- fs::path(Sys.getenv("ST_PROJECT_FOLDER_OUTPUT"))
-  if (fs::dir_exists(out_path)) fs::dir_delete(out_path)
+  in_agnostic <- "/home/mauro/tmp/st/ST_INPUTS_MASTER"
+  in_specific <- "/home/mauro/tmp/st/ST_TESTING_BONDS/inputs"
+  out <- tempfile()
+  fs::dir_create(out)
 
-x <- suppressWarnings(capture.output(
-  run_stress_test("bonds",
-    input_path_project_agnostic = get_st_data_path(),
-    input_path_project_specific = get_st_data_path("ST_PROJECT_FOLDER_INPUT"),
-    output_path = get_st_data_path("ST_PROJECT_FOLDER_OUTPUT"),
-    term = 1:2
-  )
-))
+  x <- suppressWarnings(capture.output(
+    run_stress_test("bonds",
+      input_path_project_agnostic = in_agnostic,
+      input_path_project_specific = in_specific,
+      output_path = out,
+      term = 1:2
+    )
+  ))
 
-  data <- purrr::map(fs::dir_ls(out_path), readr::read_csv, col_types = list())
+  data <- purrr::map(fs::dir_ls(out), readr::read_csv, col_types = list())
   expect_true(all(purrr::map_lgl(data, ~rlang::has_name(.x, "term_arg"))))
 })


### PR DESCRIPTION
Update tests of `run_stress_test()` to use the new paths added to the signature.

Thanks testthat:

```r
Error (test-run_stress_test.R:10:3): output includes argument names with suffix '_arg'
Error: `var` is unset. Please add data path as envvar or R option.
Backtrace:
  1. base::suppressWarnings(...) test-run_stress_test.R:10:2
  5. r2dii.climate.stress.test::run_stress_test(...)
  6. purrr::map(1:nrow(args_tibble), run_stress_test_iteration, args_tibble = args_tibble) /home/mauro/git/r2dii.climate.stress.test/R/run_stress_test.R:60:2
  7. r2dii.climate.stress.test:::.f(.x[[i]], ...)
 12. r2dii.climate.stress.test::read_and_prepare_project_agnostic_data(...) /home/mauro/git/r2dii.climate.stress.test/R/run_stress_test.R:178:2
 21. r2dii.climate.stress.test::get_st_data_path()
```﻿
