### PR TITLE
Get path from argument, not from envvar

### DIFF
--- a/R/read_and_prepare.R
+++ b/R/read_and_prepare.R
@@ -56,7 +56,7 @@ read_and_prepare_project_agnostic_data <- function(start_year, end_year, company
     )
 
   financial_data <- read_financial_data(
-    path = file.path(get_st_data_path(), "prewrangled_financial_data_stress_test.csv")
+    path = file.path(path, "prewrangled_financial_data_stress_test.csv")
   ) %>%
     check_financial_data(asset_type = asset_type)
 


### PR DESCRIPTION
Closes #203

We no longer force users to set envvars.

Thanks testthat:

```r
Error (test-run_stress_test.R:9:1): output includes argument names with suffix '_arg'
Error: `var` is unset. Please add data path as envvar or R option.
Backtrace:
 1. base::suppressWarnings(...) test-run_stress_test.R:9:0
 7. r2dii.climate.stress.test::get_st_data_path("ST_PROJECT_FOLDER_INPUT")
```