### PR TITLE
(Minor) Multiple inputs to asset_type throws surprising error message

### DIFF
--- a/tests/testthat/_snaps/run_stress_test.md
+++ b/tests/testthat/_snaps/run_stress_test.md
@@ -1,0 +1,6 @@
+# with multiple inputs to non-iterable arguments errors gracefully
+
+    All input arguments need to hold values.
+    x Missing arguments: input_path_project_specific, input_path_project_agnostic, output_path.
+    i Did you provide all input arguemnts correctly?.
+

--- a/tests/testthat/_snaps/run_stress_test.md
+++ b/tests/testthat/_snaps/run_stress_test.md
@@ -1,5 +1,11 @@
 # with multiple inputs to non-iterable arguments errors gracefully
 
+    Must not provide more than one value for not iterateable argument
+    x Arguments with multiple values: asset_type.
+    i Please coorect your function call
+
+---
+
     All input arguments need to hold values.
     x Missing arguments: input_path_project_specific, input_path_project_agnostic, output_path.
     i Did you provide all input arguemnts correctly?.

--- a/tests/testthat/test-run_stress_test.R
+++ b/tests/testthat/test-run_stress_test.R
@@ -21,3 +21,9 @@ test_that("output includes argument names with suffix '_arg'", {
   cols_from_arguments_have_suffix_arg <- purrr::map_lgl(data, ~rlang::has_name(.x, "term_arg"))
   expect_true(all(cols_from_arguments_have_suffix_arg))
 })
+
+test_that("with multiple inputs to non-iterable arguments errors gracefully", {
+  # FIXME: The error message is wrong. See */*/_snaps
+  too_long <- 1:2
+  expect_snapshot_error(run_stress_test(asset_type = too_long))
+})

--- a/tests/testthat/test-run_stress_test.R
+++ b/tests/testthat/test-run_stress_test.R
@@ -23,7 +23,13 @@ test_that("output includes argument names with suffix '_arg'", {
 })
 
 test_that("with multiple inputs to non-iterable arguments errors gracefully", {
-  # FIXME: The error message is wrong. See */*/_snaps
   too_long <- 1:2
-  expect_snapshot_error(run_stress_test(asset_type = too_long))
+  expect_snapshot_error(
+    run_stress_test(asset_type = too_long, "a", "b", tempdir())
+  )
+
+  # FIXME: Not the error I expect
+  expect_snapshot_error(
+    run_stress_test(asset_type = too_long)
+  )
 })


### PR DESCRIPTION
Overall I think this is minor.

This PR exposes what I think is unespected behaviour: I expect an error about `asset_type` before an error about missing arguments.

``` r
library(r2dii.climate.stress.test)

too_long <- 1:2
run_stress_test(asset_type = too_long)
#> -- Running transition risk stress test
#> Error: All input arguments need to hold values.
#> x Missing arguments: input_path_project_specific, input_path_project_agnostic, output_path.
#> ℹ Did you provide all input arguemnts correctly?.
```

<sup>Created on 2021-11-15 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>

-

The error I expect is this:

``` r
library(r2dii.climate.stress.test)

too_long <- 1:2
run_stress_test(asset_type = too_long, "a", "b", tempdir())
#> -- Running transition risk stress test
#> Error: Must not provide more than one value for not iterateable argument
#> x Arguments with multiple values: asset_type.
#> ℹ Please coorect your function call
```

<sup>Created on 2021-11-15 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>