### PR TITLE
Suppress message about the need for `dplyr::all_of()`

### DIFF
--- a/R/run_stress_test.R
+++ b/R/run_stress_test.R
@@ -103,7 +103,7 @@ run_stress_test_iteration <- function(n, args_tibble) {
     as.list()
 
   arg_tibble_row <- arg_tibble_row %>%
-    dplyr::select(-setup_vars_lookup) %>%
+    dplyr::select(-dplyr::all_of(setup_vars_lookup)) %>%
     dplyr::rename_with(~paste0(.x, "_arg"))
 
   st_result <- do.call(args = arg_list_row, what = run_stress_test_impl) %>%


### PR DESCRIPTION
Thanks testthat

    ⠏ |u    0 | run_stress_test                                                                                                                                           Note: Using an external vector in selections is ambiguous.
    i Use `all_of(setup_vars_lookup)` instead of `setup_vars_lookup` to silence this message.
    i See <https://tidyselect.r-lib.org/reference/faq-external-vector.html>.
    This message is displayed once per session.
