### PR TITLE
New ./install.R to install the package from source

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -27,3 +27,4 @@
 ^docs$
 ^pkgdown$
 ^data-raw$
+^install\.R$

--- a/install.R
+++ b/install.R
@@ -1,0 +1,7 @@
+if (!requireNamespace("devtools", quietly = TRUE)) {
+  stop("Must install devtools. Run: install.packages('devtools')", call. = FALSE)
+}
+
+devtools::install_deps()
+devtools::install()
+


### PR DESCRIPTION
Just run `source("install.R")`.

Demo (4' 25''): https://youtu.be/wowpe_f159Y