### PR TITLE
Sanitize timestamp

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -445,7 +445,10 @@ customise_output_path <- function(output_path, iter_var) {
     )
   }
 
-  output_path_custom <- file.path(output_path, paste(Sys.time(), iter_var, sep = "_"))
+  timestamp <- paste(Sys.time(), iter_var, sep = "_")
+  timestamp <- gsub(" ", "_", timestamp)
+  timestamp <- gsub(":", "-", timestamp)
+  output_path_custom <- file.path(output_path, timestamp)
 
   dir.create(output_path_custom)
 


### PR DESCRIPTION
Closes #226 


``` r
devtools::load_all()
#> ℹ Loading r2dii.climate.stress.test
in_agnostic <- fs::path_home("Downloads", "st", "ST_INPUTS_MASTER")
in_specific <- fs::path_home("Downloads", "st", "ST_TESTING_BONDS", "inputs")
out <- tempfile()
fs::dir_create(out)

x <- suppressWarnings(capture.output(
  run_stress_test("bonds", in_specific, in_agnostic, out)
))

fs::dir_tree(out)
#> /tmp/Rtmp3MTVj7/file118f96fd1198e
#> └── 2021-11-17_10-29-40_standard
#>     ├── log_file_standard.txt
#>     ├── stress_test_results_bonds_comp_el_standard.csv
#>     ├── stress_test_results_bonds_comp_standard.csv
#>     ├── stress_test_results_bonds_port_standard.csv
#>     ├── stress_test_results_bonds_sector_pd_changes_annual_standard.csv
#>     └── stress_test_results_bonds_sector_pd_changes_overall_standard.csv
```

<sup>Created on 2021-11-17 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>