### PR TITLE
Run usethis::use_tidy_style()

### DIFF
--- a/R/calc_survival_probability_merton.R
+++ b/R/calc_survival_probability_merton.R
@@ -18,7 +18,6 @@
 #'
 #' @return A vector holding survival probabilities,
 calc_survival_probability_merton <- function(L, V0, sigma, r, t) {
-
   input_args <- list(L, V0, sigma, r, t)
 
   if (dplyr::n_distinct(purrr::map_int(input_args, length)) > 1) {
@@ -36,7 +35,6 @@ calc_survival_probability_merton <- function(L, V0, sigma, r, t) {
   if (!all(unique(purrr::map_lgl(list(L, V0, sigma, t), function(x) {
     all(x > 0)
   })))) {
-
     stop(paste0("Unexpected non positive numbers detected on at least one of arguments L, V0, sigma, t."))
   }
 

--- a/R/calculate.R
+++ b/R/calculate.R
@@ -107,22 +107,22 @@ calculate_exposure_by_technology_and_company <- function(asset_type,
     )
 
   exposure_by_technology_and_company <- input_data_list$pacta_results %>%
-   dplyr::filter(
-     .data$year == .env$start_year,
-     .data$scenario %in% .env$scenario_to_follow_ls
-   ) %>%
-   dplyr::inner_join(
-     y = financial_data_subset,
-     by = merge_cols
-   ) %>%
-   # TODO:  what to do with entries that have NAs for pd?
-   dplyr::select(
-     investor_name, portfolio_name, company_name, ald_sector, technology,
-     scenario_geography, year, plan_carsten, plan_sec_carsten, term, pd
-   ) %>%
-   report_all_duplicate_kinds(
-     composite_unique_cols = names(.)
-   )
+    dplyr::filter(
+      .data$year == .env$start_year,
+      .data$scenario %in% .env$scenario_to_follow_ls
+    ) %>%
+    dplyr::inner_join(
+      y = financial_data_subset,
+      by = merge_cols
+    ) %>%
+    # TODO:  what to do with entries that have NAs for pd?
+    dplyr::select(
+      investor_name, portfolio_name, company_name, ald_sector, technology,
+      scenario_geography, year, plan_carsten, plan_sec_carsten, term, pd
+    ) %>%
+    report_all_duplicate_kinds(
+      composite_unique_cols = names(.)
+    )
 
   n_companies_pre <- length(unique(exposure_by_technology_and_company$company_name))
 
@@ -132,15 +132,18 @@ calculate_exposure_by_technology_and_company <- function(asset_type,
   n_companies_post <- length(unique(exposure_by_technology_and_company_filtered$company_name))
 
   if (n_companies_pre > n_companies_post) {
-    percent_loss <- (n_companies_pre - n_companies_post) * 100/n_companies_pre
+    percent_loss <- (n_companies_pre - n_companies_post) * 100 / n_companies_pre
     affected_companies <- sort(
-      setdiff(exposure_by_technology_and_company$company_name,
-              exposure_by_technology_and_company_filtered$company_name)
+      setdiff(
+        exposure_by_technology_and_company$company_name,
+        exposure_by_technology_and_company_filtered$company_name
       )
+    )
     paste_write(
       format_indent_1(), "When filtering out holdings with exposures of 0 value, dropped rows for",
       n_companies_pre - n_companies_post, "out of", n_companies_pre, "companies",
-    log_path = log_path)
+      log_path = log_path
+    )
     paste_write(format_indent_2(), "percent loss:", percent_loss, log_path = log_path)
     paste_write(format_indent_2(), "affected companies:", log_path = log_path)
     purrr::walk(affected_companies, function(company) {

--- a/R/calculate_annual_pd_changes.R
+++ b/R/calculate_annual_pd_changes.R
@@ -21,7 +21,6 @@ calculate_pd_change_annual <- function(data,
                                        shock_year = NULL,
                                        end_of_analysis = NULL,
                                        risk_free_interest_rate = NULL) {
-
   force(data)
   shock_year %||% stop("Must provide input for 'shock_year'", call. = FALSE)
   end_of_analysis %||% stop("Must provide input for 'end_of_analysis'", call. = FALSE)
@@ -108,5 +107,4 @@ calculate_pd_change_annual <- function(data,
     )
 
   return(results)
-
 }

--- a/R/check_and_filter_data.R
+++ b/R/check_and_filter_data.R
@@ -68,8 +68,10 @@ check_and_filter_data <- function(st_data_list, start_year, end_year,
     c("year", "sector", "technology"),
     c("scenario_geography", "scenario", "ald_sector", "technology", "year"),
     c("company_name", "company_id"),
-    c("year", "equity_market", "ald_sector", "technology", "scenario", "allocation",
-      "scenario_geography", "company_name", "id", "investor_name", "portfolio_name"),
+    c(
+      "year", "equity_market", "ald_sector", "technology", "scenario", "allocation",
+      "scenario_geography", "company_name", "id", "investor_name", "portfolio_name"
+    ),
     c("financial_sector", "investor_name", "portfolio_name")
   )
 

--- a/R/exclude_companies.R
+++ b/R/exclude_companies.R
@@ -21,7 +21,6 @@ exclude_companies <- function(data,
                               exclusion = NULL,
                               scenario_baseline = NULL,
                               scenario_ls = NULL) {
-
   if (is.null(exclusion)) {
     return(data)
   }

--- a/R/filter.R
+++ b/R/filter.R
@@ -9,10 +9,9 @@
 #' @param stage String, indicating if checks are done for overall or annual
 #'   results.
 #'
-#'@return Tibble holding rows from `data` that are compatible with constraints
+#' @return Tibble holding rows from `data` that are compatible with constraints
 #'  of [calc_survival_probability_merton()].
 keep_merton_compatible_rows <- function(data, stage) {
-
   if (!stage %in% c("overall", "annual")) {
     stop("Invalid value for argument stage")
   }
@@ -33,7 +32,7 @@ keep_merton_compatible_rows <- function(data, stage) {
     dplyr::select(-.data$V0_base, -.data$V0_late_sudden)
 
   if (nrow(data_filtered) < nrow(data)) {
-    cat(paste0("Removed ", nrow(data) - nrow(data_filtered)," rows when checking for compatibility with merton model."))
+    cat(paste0("Removed ", nrow(data) - nrow(data_filtered), " rows when checking for compatibility with merton model."))
 
     if (nrow(data_filtered) == 0) {
       stop("No data remain after removing rows that are not compatible with merton model.")

--- a/R/interpolate_automotive_scenario.R
+++ b/R/interpolate_automotive_scenario.R
@@ -82,4 +82,3 @@ correct_automotive_scendata <- function(data, interpolation_years = NULL) {
 
   data
 }
-

--- a/R/lookup.R
+++ b/R/lookup.R
@@ -59,6 +59,7 @@ equity_market_filter_lookup <- "GlobalMarket"
 
 # technology and sector mapping between P4I and P4B
 # HDV and shipping not consistently defined across both versions at this time
+# styler: off
 p4i_p4b_sector_technology_lookup <- tibble::tribble(
   ~sector_p4b,   ~technology_p4b,             ~sector_p4i,    ~technology_p4i,
   "automotive",  "electric",                 "Automotive",   "Electric",
@@ -83,19 +84,22 @@ p4i_p4b_sector_technology_lookup <- tibble::tribble(
   "steel",       "dc-electric arc furnace",  "Steel",        "Dc-Electric Arc Furnace",
   "steel",       "open hearth meltshop",     "Steel",        "Open Hearth Meltshop"
 )
+# styler: on
 
 # scenario mapping between P4I and P4B
 # TODO: should the implicit mappin a la sps is the follow up NPS be hapening elsewhere?
+# styler: off
 p4i_p4b_scenario_lookup <- tibble::tribble(
-  ~scenario_p4b,   ~scenario_p4i,
-  "target_cps",   "CPS",
-  "target_rts",   "NPS",
-  "target_sps",   "NPS",
-  "target_steps", "NPS",
-  "target_2ds",   "SDS",
-  "target_sds",   "SDS",
-  "target_b2ds",  "B2DS",
+   ~scenario_p4b,   ~scenario_p4i,
+    "target_cps",           "CPS",
+    "target_rts",           "NPS",
+    "target_sps",           "NPS",
+  "target_steps",           "NPS",
+    "target_2ds",           "SDS",
+    "target_sds",           "SDS",
+   "target_b2ds",          "B2DS",
 )
+# styler: on
 
 # P4B scenario list
 p4b_scenarios_lookup <- c("target_b2ds", "target_cps", "target_rts",

--- a/R/lookup.R
+++ b/R/lookup.R
@@ -60,47 +60,49 @@ equity_market_filter_lookup <- "GlobalMarket"
 # technology and sector mapping between P4I and P4B
 # HDV and shipping not consistently defined across both versions at this time
 p4i_p4b_sector_technology_lookup <- tibble::tribble(
-  ~sector_p4b,   ~technology_p4b,             ~sector_p4i,    ~technology_p4i,
-  "automotive",  "electric",                 "Automotive",   "Electric",
-  "automotive",  "hybrid",                   "Automotive",   "Hybrid",
-  "automotive",  "fuelcell",                 "Automotive",   "FuelCell",
-  "automotive",  "ice",                      "Automotive",   "ICE",
-  "coal",        "coal",                     "Coal",         "Coal",
-  "oil and gas", "gas",                      "Oil&Gas",      "Gas",
-  "oil and gas", "oil",                      "Oil&Gas",      "Oil",
-  "power",       "coalcap",                  "Power",        "CoalCap",
-  "power",       "gascap",                   "Power",        "GasCap",
-  "power",       "hydrocap",                 "Power",        "HydroCap",
-  "power",       "nuclearcap",               "Power",        "NuclearCap",
-  "power",       "oilcap",                   "Power",        "OilCap",
-  "power",       "renewablescap",            "Power",        "RenewablesCap",
-  "aviation",    "freight",                  "Aviation",     "Freight",
-  "aviation",    "passenger",                "Aviation",     "Passenger",
-  "cement",      "grinding",                 "Cement",       "Grinding",
-  "cement",      "integrated facility",      "Cement",       "Integrated facility",
-  "steel",       "ac-electric arc furnace",  "Steel",        "Ac-Electric Arc Furnace",
-  "steel",       "bof shop",                 "Steel",        "Bof Shop",
-  "steel",       "dc-electric arc furnace",  "Steel",        "Dc-Electric Arc Furnace",
-  "steel",       "open hearth meltshop",     "Steel",        "Open Hearth Meltshop"
+  ~sector_p4b, ~technology_p4b, ~sector_p4i, ~technology_p4i,
+  "automotive", "electric", "Automotive", "Electric",
+  "automotive", "hybrid", "Automotive", "Hybrid",
+  "automotive", "fuelcell", "Automotive", "FuelCell",
+  "automotive", "ice", "Automotive", "ICE",
+  "coal", "coal", "Coal", "Coal",
+  "oil and gas", "gas", "Oil&Gas", "Gas",
+  "oil and gas", "oil", "Oil&Gas", "Oil",
+  "power", "coalcap", "Power", "CoalCap",
+  "power", "gascap", "Power", "GasCap",
+  "power", "hydrocap", "Power", "HydroCap",
+  "power", "nuclearcap", "Power", "NuclearCap",
+  "power", "oilcap", "Power", "OilCap",
+  "power", "renewablescap", "Power", "RenewablesCap",
+  "aviation", "freight", "Aviation", "Freight",
+  "aviation", "passenger", "Aviation", "Passenger",
+  "cement", "grinding", "Cement", "Grinding",
+  "cement", "integrated facility", "Cement", "Integrated facility",
+  "steel", "ac-electric arc furnace", "Steel", "Ac-Electric Arc Furnace",
+  "steel", "bof shop", "Steel", "Bof Shop",
+  "steel", "dc-electric arc furnace", "Steel", "Dc-Electric Arc Furnace",
+  "steel", "open hearth meltshop", "Steel", "Open Hearth Meltshop"
 )
 
 # scenario mapping between P4I and P4B
 # TODO: should the implicit mappin a la sps is the follow up NPS be hapening elsewhere?
 p4i_p4b_scenario_lookup <- tibble::tribble(
-  ~scenario_p4b,   ~scenario_p4i,
-  "target_cps",   "CPS",
-  "target_rts",   "NPS",
-  "target_sps",   "NPS",
+  ~scenario_p4b, ~scenario_p4i,
+  "target_cps", "CPS",
+  "target_rts", "NPS",
+  "target_sps", "NPS",
   "target_steps", "NPS",
-  "target_2ds",   "SDS",
-  "target_sds",   "SDS",
-  "target_b2ds",  "B2DS",
+  "target_2ds", "SDS",
+  "target_sds", "SDS",
+  "target_b2ds", "B2DS",
 )
 
 # P4B scenario list
-p4b_scenarios_lookup <- c("target_b2ds", "target_cps", "target_rts",
-                          "target_sps", "target_steps", "target_2ds",
-                          "target_sds")
+p4b_scenarios_lookup <- c(
+  "target_b2ds", "target_cps", "target_rts",
+  "target_sps", "target_steps", "target_2ds",
+  "target_sds"
+)
 
 # holds names of input arguments to run_stress_test that are not model paramters
 setup_vars_lookup <- c("input_path_project_agnostic", "input_path_project_specific", "output_path", "iter_var", "return_results")

--- a/R/lookup.R
+++ b/R/lookup.R
@@ -102,9 +102,11 @@ p4i_p4b_scenario_lookup <- tibble::tribble(
 # styler: on
 
 # P4B scenario list
-p4b_scenarios_lookup <- c("target_b2ds", "target_cps", "target_rts",
-                          "target_sps", "target_steps", "target_2ds",
-                          "target_sds")
+p4b_scenarios_lookup <- c(
+  "target_b2ds", "target_cps", "target_rts",
+  "target_sps", "target_steps", "target_2ds",
+  "target_sds"
+)
 
 # holds names of input arguments to run_stress_test that are not model paramters
 setup_vars_lookup <- c("input_path_project_agnostic", "input_path_project_specific", "output_path", "iter_var", "return_results")

--- a/R/lookup.R
+++ b/R/lookup.R
@@ -60,49 +60,47 @@ equity_market_filter_lookup <- "GlobalMarket"
 # technology and sector mapping between P4I and P4B
 # HDV and shipping not consistently defined across both versions at this time
 p4i_p4b_sector_technology_lookup <- tibble::tribble(
-  ~sector_p4b, ~technology_p4b, ~sector_p4i, ~technology_p4i,
-  "automotive", "electric", "Automotive", "Electric",
-  "automotive", "hybrid", "Automotive", "Hybrid",
-  "automotive", "fuelcell", "Automotive", "FuelCell",
-  "automotive", "ice", "Automotive", "ICE",
-  "coal", "coal", "Coal", "Coal",
-  "oil and gas", "gas", "Oil&Gas", "Gas",
-  "oil and gas", "oil", "Oil&Gas", "Oil",
-  "power", "coalcap", "Power", "CoalCap",
-  "power", "gascap", "Power", "GasCap",
-  "power", "hydrocap", "Power", "HydroCap",
-  "power", "nuclearcap", "Power", "NuclearCap",
-  "power", "oilcap", "Power", "OilCap",
-  "power", "renewablescap", "Power", "RenewablesCap",
-  "aviation", "freight", "Aviation", "Freight",
-  "aviation", "passenger", "Aviation", "Passenger",
-  "cement", "grinding", "Cement", "Grinding",
-  "cement", "integrated facility", "Cement", "Integrated facility",
-  "steel", "ac-electric arc furnace", "Steel", "Ac-Electric Arc Furnace",
-  "steel", "bof shop", "Steel", "Bof Shop",
-  "steel", "dc-electric arc furnace", "Steel", "Dc-Electric Arc Furnace",
-  "steel", "open hearth meltshop", "Steel", "Open Hearth Meltshop"
+  ~sector_p4b,   ~technology_p4b,             ~sector_p4i,    ~technology_p4i,
+  "automotive",  "electric",                 "Automotive",   "Electric",
+  "automotive",  "hybrid",                   "Automotive",   "Hybrid",
+  "automotive",  "fuelcell",                 "Automotive",   "FuelCell",
+  "automotive",  "ice",                      "Automotive",   "ICE",
+  "coal",        "coal",                     "Coal",         "Coal",
+  "oil and gas", "gas",                      "Oil&Gas",      "Gas",
+  "oil and gas", "oil",                      "Oil&Gas",      "Oil",
+  "power",       "coalcap",                  "Power",        "CoalCap",
+  "power",       "gascap",                   "Power",        "GasCap",
+  "power",       "hydrocap",                 "Power",        "HydroCap",
+  "power",       "nuclearcap",               "Power",        "NuclearCap",
+  "power",       "oilcap",                   "Power",        "OilCap",
+  "power",       "renewablescap",            "Power",        "RenewablesCap",
+  "aviation",    "freight",                  "Aviation",     "Freight",
+  "aviation",    "passenger",                "Aviation",     "Passenger",
+  "cement",      "grinding",                 "Cement",       "Grinding",
+  "cement",      "integrated facility",      "Cement",       "Integrated facility",
+  "steel",       "ac-electric arc furnace",  "Steel",        "Ac-Electric Arc Furnace",
+  "steel",       "bof shop",                 "Steel",        "Bof Shop",
+  "steel",       "dc-electric arc furnace",  "Steel",        "Dc-Electric Arc Furnace",
+  "steel",       "open hearth meltshop",     "Steel",        "Open Hearth Meltshop"
 )
 
 # scenario mapping between P4I and P4B
 # TODO: should the implicit mappin a la sps is the follow up NPS be hapening elsewhere?
 p4i_p4b_scenario_lookup <- tibble::tribble(
-  ~scenario_p4b, ~scenario_p4i,
-  "target_cps", "CPS",
-  "target_rts", "NPS",
-  "target_sps", "NPS",
+  ~scenario_p4b,   ~scenario_p4i,
+  "target_cps",   "CPS",
+  "target_rts",   "NPS",
+  "target_sps",   "NPS",
   "target_steps", "NPS",
-  "target_2ds", "SDS",
-  "target_sds", "SDS",
-  "target_b2ds", "B2DS",
+  "target_2ds",   "SDS",
+  "target_sds",   "SDS",
+  "target_b2ds",  "B2DS",
 )
 
 # P4B scenario list
-p4b_scenarios_lookup <- c(
-  "target_b2ds", "target_cps", "target_rts",
-  "target_sps", "target_steps", "target_2ds",
-  "target_sds"
-)
+p4b_scenarios_lookup <- c("target_b2ds", "target_cps", "target_rts",
+                          "target_sps", "target_steps", "target_2ds",
+                          "target_sds")
 
 # holds names of input arguments to run_stress_test that are not model paramters
 setup_vars_lookup <- c("input_path_project_agnostic", "input_path_project_specific", "output_path", "iter_var", "return_results")

--- a/R/read_capacity_factors.R
+++ b/R/read_capacity_factors.R
@@ -60,7 +60,6 @@ read_capacity_factors <- function(path = NULL,
         "technology", "capacity_factor", "scenario_geography"
       )
     )
-
   } else {
     # ADO 2393 - this should keep the source and filter based on global settings
     # not in this hard coded manner

--- a/R/read_financial_data.R
+++ b/R/read_financial_data.R
@@ -9,17 +9,17 @@ read_financial_data <- function(path = NULL) {
   path %||% stop("Must provide 'path'")
 
   data <- validate_file_exists(file.path(path)) %>%
-  readr::read_csv(
-    col_types = readr::cols_only(
-      company_name = "c",
-      company_id = "d",
-      corporate_bond_ticker = "c",
-      pd = "d",
-      net_profit_margin = "d",
-      debt_equity_ratio = "d",
-      volatility = "d"
+    readr::read_csv(
+      col_types = readr::cols_only(
+        company_name = "c",
+        company_id = "d",
+        corporate_bond_ticker = "c",
+        pd = "d",
+        net_profit_margin = "d",
+        debt_equity_ratio = "d",
+        volatility = "d"
+      )
     )
-  )
 
   return(data)
 }

--- a/R/read_ngfs_carbon_tax.R
+++ b/R/read_ngfs_carbon_tax.R
@@ -10,16 +10,16 @@ read_ngfs_carbon_tax <- function(path = NULL) {
 
   data <- validate_file_exists(path) %>%
     readr::read_csv(
-    col_types = readr::cols(
-      year = "d",
-      model = "c",
-      scenario = "c",
-      scenario_geography = "c",
-      variable = "c",
-      unit = "c",
-      carbon_tax = "d"
+      col_types = readr::cols(
+        year = "d",
+        model = "c",
+        scenario = "c",
+        scenario_geography = "c",
+        variable = "c",
+        unit = "c",
+        carbon_tax = "d"
+      )
     )
-  )
 
   expected_columns <- c(
     "year", "model", "scenario", "scenario_geography", "variable", "unit",

--- a/R/read_price_data.R
+++ b/R/read_price_data.R
@@ -40,20 +40,19 @@ read_price_data <- function(path,
 #'   It is expected to work with data based on IEA WEO 2020.
 #' @inheritParams read_price_data
 read_price_data_internal <- function(path) {
-
   data <- validate_file_exists(path) %>%
     readr::read_csv(
-    col_types = readr::cols(
-      year = "d",
-      source = "c",
-      scenario = "c",
-      scenario_geography = "c",
-      technology = "c",
-      indicator = "c",
-      unit = "c",
-      price = "d"
+      col_types = readr::cols(
+        year = "d",
+        source = "c",
+        scenario = "c",
+        scenario_geography = "c",
+        technology = "c",
+        indicator = "c",
+        unit = "c",
+        price = "d"
+      )
     )
-  )
 
   validate_data_has_expected_cols(
     data = data,
@@ -73,27 +72,25 @@ read_price_data_internal <- function(path) {
 #' @description This function reads in price data using the old wide data format.
 #' @inheritParams read_price_data
 read_price_data_internal_old <- function(path) {
-
-
   data <- validate_file_exists(path) %>%
     readr::read_csv(
-    col_types = readr::cols(
-      year = "d",
-      sector = "c",
-      technology = "c",
-      sector_unit_ds = "c",
-      price_unit_iea = "c",
-      price_unit_etr = "c",
-      B2DS = "d",
-      b2ds_source = "c",
-      NPS = "d",
-      nps_source = "c",
-      SDS = "d",
-      sds_source = "c",
-      Baseline = "d",
-      baseline_source = "c"
+      col_types = readr::cols(
+        year = "d",
+        sector = "c",
+        technology = "c",
+        sector_unit_ds = "c",
+        price_unit_iea = "c",
+        price_unit_etr = "c",
+        B2DS = "d",
+        b2ds_source = "c",
+        NPS = "d",
+        nps_source = "c",
+        SDS = "d",
+        sds_source = "c",
+        Baseline = "d",
+        baseline_source = "c"
+      )
     )
-  )
 
   validate_data_has_expected_cols(
     data = data,

--- a/R/read_scenario_data.R
+++ b/R/read_scenario_data.R
@@ -6,7 +6,6 @@
 #'
 #' @return A tibble holding scenario data.
 read_scenario_data <- function(path) {
-
   scenario_data <- validate_file_exists(path) %>%
     readr::read_csv(
       col_types = readr::cols(

--- a/R/read_transition_scenarios.R
+++ b/R/read_transition_scenarios.R
@@ -20,16 +20,16 @@ read_transition_scenarios <- function(path = NULL,
 
   data <- validate_file_exists(path) %>%
     readr::read_csv(
-    col_types = readr::cols(
-      scenario_name = "c",
-      year_of_shock = "d",
-      overshoot_method = "l",
-      duration_of_shock = "d",
-      use_prod_forecasts_ls = "l",
-      use_prod_forecasts_baseline = "l",
-      .default = readr::col_number()
+      col_types = readr::cols(
+        scenario_name = "c",
+        year_of_shock = "d",
+        overshoot_method = "l",
+        duration_of_shock = "d",
+        use_prod_forecasts_ls = "l",
+        use_prod_forecasts_baseline = "l",
+        .default = readr::col_number()
+      )
     )
-  )
 
   data <- data %>%
     dplyr::mutate(

--- a/R/run_prep_calculation_loans.R
+++ b/R/run_prep_calculation_loans.R
@@ -15,7 +15,6 @@ run_prep_calculation_loans <- function(input_path_project_specific,
                                        input_path_project_agnostic,
                                        data_prep_output_path,
                                        credit_type = "outstanding") {
-
   cat("-- Running data preparation. \n")
 
   #### Validate input-----------------------------------------------------------
@@ -92,8 +91,8 @@ run_prep_calculation_loans <- function(input_path_project_specific,
   # Production forecast data
   production_forecast_data <- validate_file_exists(file.path(input_path_project_agnostic, "2021-07-15_AR_2020Q4_PACTA-Data (3).xlsx")) %>%
     readxl::read_xlsx(
-    sheet = "Company Indicators - PACTA"
-  )
+      sheet = "Company Indicators - PACTA"
+    )
 
   # Scenario data - market share
   scenario_data_market_share <- validate_file_exists(file.path(input_path_project_agnostic, "scenario_2020.csv")) %>%
@@ -126,8 +125,8 @@ run_prep_calculation_loans <- function(input_path_project_specific,
         nrow(matched) - nrow(matched_non_negative),
         " loans removed from the matched loan book because of negative loan
         values. Please check the input loan book to address this issue."
-      )
-      , call. = FALSE
+      ),
+      call. = FALSE
     )
   }
 
@@ -213,7 +212,8 @@ run_prep_calculation_loans <- function(input_path_project_specific,
     dplyr::inner_join(
       # ADO 2393 - use distinct to only map sectors, not technlogies
       p4i_p4b_sector_technology_lookup %>% dplyr::distinct(.data$sector_p4b, .data$sector_p4i),
-      by = c("sector_ald" = "sector_p4b")) %>%
+      by = c("sector_ald" = "sector_p4b")
+    ) %>%
     dplyr::mutate(sector_ald = .data$sector_p4i) %>%
     dplyr::select(
       .data$sector_ald,
@@ -291,7 +291,7 @@ run_prep_calculation_loans <- function(input_path_project_specific,
     ) %>%
     dplyr::rename(
       production_unweighted = .data$production
-    )  %>%
+    ) %>%
     dplyr::mutate(technology_share = round(.data$technology_share, 8)) %>%
     report_all_duplicate_kinds(
       composite_unique_cols = c(
@@ -335,6 +335,4 @@ run_prep_calculation_loans <- function(input_path_project_specific,
     )
 
   cat("-- Exported prepared data to designated output path. \n")
-
 }
-

--- a/R/run_stress_test.R
+++ b/R/run_stress_test.R
@@ -161,7 +161,6 @@ run_stress_test_impl <- function(asset_type,
                                  term,
                                  company_exclusion,
                                  iter_var) {
-
   args_list <- mget(names(formals()), sys.frame(sys.nframe()))
 
   log_path <- file.path(output_path, paste0("log_file_", iter_var, ".txt"))

--- a/R/set_tech_trajectories.R
+++ b/R/set_tech_trajectories.R
@@ -421,9 +421,9 @@ filter_negative_late_and_sudden <- function(data_with_late_and_sudden, log_path)
     # log_path will be NULL when function is called from webtool
     if (!is.null(log_path)) {
       paste_write(
-          format_indent_1(), "Removed", n_rows_before_removal - nrow(data_with_late_and_sudden),
-          "rows because negative production compensation targets were set in late and sudden production paths ways. Negative absolute production is impossible \n"
-          , log_path = log_path
+        format_indent_1(), "Removed", n_rows_before_removal - nrow(data_with_late_and_sudden),
+        "rows because negative production compensation targets were set in late and sudden production paths ways. Negative absolute production is impossible \n",
+        log_path = log_path
       )
     }
 

--- a/R/stress_test_model_functions.R
+++ b/R/stress_test_model_functions.R
@@ -15,13 +15,11 @@ f <- function(shock_strength_calc) {
 
 # LATE AND SUDDEN PRICES ----------------------------------------
 
-late_sudden_prices <- function(
-    SDS_price,
-    Baseline_price,
-    year_of_shock,
-    start_year,
-    duration_of_shock
-  ) {
+late_sudden_prices <- function(SDS_price,
+                               Baseline_price,
+                               year_of_shock,
+                               start_year,
+                               duration_of_shock) {
   # input:
   # vector with SDS and Baseline (NPS) prices
   # Calculates late and sudden prices based on these two vectors
@@ -177,7 +175,6 @@ check_scenario_timeframe <- function(scenario_data, start_year = start_year, end
 # check if the scenarios selected in the stress test project at hand
 # are compatible with the scenarios passed from the PACTA results input
 check_scenario_settings <- function(portfolio, scenario_selections = scenarios) {
-
   if (!all(scenario_selections %in% unique(portfolio$scenario))) {
     stop(
       paste0(

--- a/R/utils.R
+++ b/R/utils.R
@@ -127,7 +127,6 @@ validate_data_has_expected_cols <- function(data,
 #'
 #' @return input `data`.
 report_all_duplicate_kinds <- function(data, composite_unique_cols, throw_error = TRUE) {
-
   validate_data_has_expected_cols(
     data = data,
     expected_columns = composite_unique_cols
@@ -217,7 +216,6 @@ report_duplicates <- function(data, cols, throw_error = TRUE) {
 #'
 #' @return NULL
 report_company_drops <- function(data_list, asset_type, log_path) {
-
   if (asset_type == "bonds") {
     merge_cols <- c("company_name", "id" = "corporate_bond_ticker")
   } else {
@@ -257,7 +255,6 @@ report_company_drops <- function(data_list, asset_type, log_path) {
 #'
 #' @return The merged dataset.
 report_dropped_company_names <- function(data_x, data_y, name_y, merge_cols, name_x = "PACTA results", log_path) {
-
   data <- data_x %>%
     dplyr::inner_join(
       data_y,
@@ -268,7 +265,7 @@ report_dropped_company_names <- function(data_x, data_y, name_y, merge_cols, nam
   n_companies <- length(unique(data$company_name))
 
   if (n_companies < n_companies_x) {
-    percent_loss <- (n_companies_x - n_companies) * 100/n_companies_x
+    percent_loss <- (n_companies_x - n_companies) * 100 / n_companies_x
     affected_companies <- sort(setdiff(data_x$company_name, data$company_name))
     paste_write(
       format_indent_1(), "When joining", name_x, "on", name_y, "on column(s)", paste0(merge_cols, collapse = ", "), "could not match entries for",
@@ -321,7 +318,7 @@ report_missings <- function(data, name_data, throw_error = FALSE) {
 #'
 #' @return A double holding value of the flat multiplier.
 assign_flat_multiplier <- function(asset_type) {
-  flat_multiplier <- ifelse(asset_type %in% c("loans", "bonds"),  0.15, 1.0)
+  flat_multiplier <- ifelse(asset_type %in% c("loans", "bonds"), 0.15, 1.0)
   return(flat_multiplier)
 }
 
@@ -348,7 +345,6 @@ assign_lgd <- function(asset_type, lgd_senior_claims,
 #'
 #' @return String holding name of iterator variable.
 get_iter_var <- function(args_list) {
-
   iterate_arg <- purrr::map_int(args_list, length) %>%
     tibble::enframe() %>%
     dplyr::filter(.data$value > 1)
@@ -363,7 +359,7 @@ get_iter_var <- function(args_list) {
         "Must not provide more than one value for not iterateable argument",
         x = glue::glue("Arguments with multiple values: {toString(iter_var)}."),
         i = "Please coorect your function call"
-        ))
+      ))
     }
   } else {
     rlang::abort(c(
@@ -388,8 +384,12 @@ paste_write <- function(..., log_path, append = TRUE) {
 }
 
 # helper functions to indent lines in logfile
-format_indent_1 <- function() {">>"}
-format_indent_2 <- function() {"  >>"}
+format_indent_1 <- function() {
+  ">>"
+}
+format_indent_2 <- function() {
+  "  >>"
+}
 
 
 #' Checks if input args are missing

--- a/R/validate.R
+++ b/R/validate.R
@@ -14,8 +14,10 @@ validate_input_values <- function(lgd_senior_claims, lgd_subordinated_claims,
   c("company_exclusion", "asset_type") %>%
     purrr::walk(validate_values_in_values, args_list = input_args)
 
-  c("lgd_senior_claims", "lgd_subordinated_claims", "risk_free_rate",
-    "discount_rate", "div_netprofit_prop_coef", "shock_year", "term") %>%
+  c(
+    "lgd_senior_claims", "lgd_subordinated_claims", "risk_free_rate",
+    "discount_rate", "div_netprofit_prop_coef", "shock_year", "term"
+  ) %>%
     purrr::walk(validate_values_in_range, args_list = input_args)
 
   if (!all(shock_year %% 1 == 0)) {
@@ -90,7 +92,6 @@ validate_values_in_values <- function(var, args_list) {
 #'
 #' @return NULL
 validate_values_in_range <- function(var, args_list) {
-
   min <- stress_test_arguments %>%
     dplyr::filter(.data$name == .env$var) %>%
     dplyr::pull(.data$min) %>%

--- a/data-raw/stress_test_arguments.R
+++ b/data-raw/stress_test_arguments.R
@@ -4,7 +4,7 @@ stress_test_arguments <- tibble::tribble(
                "asset_type", "character",       NA, "equity, bonds, loans",         NA,         NA,
         "lgd_senior_claims",    "double",   "0.45",                     NA,      "0.3",      "0.6",
   "lgd_subordinated_claims",    "double",   "0.75",                     NA,      "0.6",      "0.9",
-#           "terminal_value",    "double",      "0",                     NA,        "0",      "0.1",
+   #       "terminal_value",    "double",      "0",                     NA,        "0",      "0.1",
            "risk_free_rate",    "double",   "0.02",                     NA,        "0",     "0.05",
             "discount_rate",    "double",   "0.02",                     NA,    "-0.01",     "0.05",
   "div_netprofit_prop_coef",    "double",      "1",                     NA,      "0.8",        "1",

--- a/data-raw/stress_test_arguments.R
+++ b/data-raw/stress_test_arguments.R
@@ -1,4 +1,4 @@
-# style: off
+# styler: off
 stress_test_arguments <- tibble::tribble(
                       ~name,       ~type, ~default,               ~allowed,       ~min,       ~max,
                "asset_type", "character",       NA, "equity, bonds, loans",         NA,         NA,
@@ -12,6 +12,6 @@ stress_test_arguments <- tibble::tribble(
                      "term",    "double",      "2",                     NA,        "1",       "10",
         "company_exclusion",   "logical",   "TRUE",          "TRUE, FALSE",         NA,         NA
 )
-# style: on
+# styler: on
 
 usethis::use_data(stress_test_arguments, overwrite = TRUE)

--- a/data-raw/stress_test_arguments.R
+++ b/data-raw/stress_test_arguments.R
@@ -1,16 +1,16 @@
 # style: off
 stress_test_arguments <- tibble::tribble(
-                      ~name,       ~type, ~default,               ~allowed,       ~min,       ~max,
-               "asset_type", "character",       NA, "equity, bonds, loans",         NA,         NA,
-        "lgd_senior_claims",    "double",   "0.45",                     NA,      "0.3",      "0.6",
-  "lgd_subordinated_claims",    "double",   "0.75",                     NA,      "0.6",      "0.9",
-#           "terminal_value",    "double",      "0",                     NA,        "0",      "0.1",
-           "risk_free_rate",    "double",   "0.02",                     NA,        "0",     "0.05",
-            "discount_rate",    "double",   "0.02",                     NA,    "-0.01",     "0.05",
-  "div_netprofit_prop_coef",    "double",      "1",                     NA,      "0.8",        "1",
-               "shock_year",    "double",   "2030",                     NA,     "2025",     "2035",
-                     "term",    "double",      "2",                     NA,        "1",       "10",
-        "company_exclusion",   "logical",   "TRUE",          "TRUE, FALSE",         NA,         NA
+  ~name, ~type, ~default, ~allowed, ~min, ~max,
+  "asset_type", "character", NA, "equity, bonds, loans", NA, NA,
+  "lgd_senior_claims", "double", "0.45", NA, "0.3", "0.6",
+  "lgd_subordinated_claims", "double", "0.75", NA, "0.6", "0.9",
+  #           "terminal_value",    "double",      "0",                     NA,        "0",      "0.1",
+  "risk_free_rate", "double", "0.02", NA, "0", "0.05",
+  "discount_rate", "double", "0.02", NA, "-0.01", "0.05",
+  "div_netprofit_prop_coef", "double", "1", NA, "0.8", "1",
+  "shock_year", "double", "2030", NA, "2025", "2035",
+  "term", "double", "2", NA, "1", "10",
+  "company_exclusion", "logical", "TRUE", "TRUE, FALSE", NA, NA
 )
 # style: on
 

--- a/data-raw/stress_test_arguments.R
+++ b/data-raw/stress_test_arguments.R
@@ -1,16 +1,16 @@
 # style: off
 stress_test_arguments <- tibble::tribble(
-  ~name, ~type, ~default, ~allowed, ~min, ~max,
-  "asset_type", "character", NA, "equity, bonds, loans", NA, NA,
-  "lgd_senior_claims", "double", "0.45", NA, "0.3", "0.6",
-  "lgd_subordinated_claims", "double", "0.75", NA, "0.6", "0.9",
-  #           "terminal_value",    "double",      "0",                     NA,        "0",      "0.1",
-  "risk_free_rate", "double", "0.02", NA, "0", "0.05",
-  "discount_rate", "double", "0.02", NA, "-0.01", "0.05",
-  "div_netprofit_prop_coef", "double", "1", NA, "0.8", "1",
-  "shock_year", "double", "2030", NA, "2025", "2035",
-  "term", "double", "2", NA, "1", "10",
-  "company_exclusion", "logical", "TRUE", "TRUE, FALSE", NA, NA
+                      ~name,       ~type, ~default,               ~allowed,       ~min,       ~max,
+               "asset_type", "character",       NA, "equity, bonds, loans",         NA,         NA,
+        "lgd_senior_claims",    "double",   "0.45",                     NA,      "0.3",      "0.6",
+  "lgd_subordinated_claims",    "double",   "0.75",                     NA,      "0.6",      "0.9",
+#           "terminal_value",    "double",      "0",                     NA,        "0",      "0.1",
+           "risk_free_rate",    "double",   "0.02",                     NA,        "0",     "0.05",
+            "discount_rate",    "double",   "0.02",                     NA,    "-0.01",     "0.05",
+  "div_netprofit_prop_coef",    "double",      "1",                     NA,      "0.8",        "1",
+               "shock_year",    "double",   "2030",                     NA,     "2025",     "2035",
+                     "term",    "double",      "2",                     NA,        "1",       "10",
+        "company_exclusion",   "logical",   "TRUE",          "TRUE, FALSE",         NA,         NA
 )
 # style: on
 

--- a/tests/testthat/test-calc_survival_probability_merton.R
+++ b/tests/testthat/test-calc_survival_probability_merton.R
@@ -61,4 +61,3 @@ test_that("Function returns vector of identical length as input args", {
 
   expect_equal(length(p_survival), 2)
 })
-

--- a/tests/testthat/test-exclude_companies.R
+++ b/tests/testthat/test-exclude_companies.R
@@ -68,5 +68,4 @@ test_that("input data is return if exclusion is NULL", {
   )
 
   expect_equal(test_excluded, test_comp_annual_profits)
-
 })

--- a/tests/testthat/test-read_transition_scenarios.R
+++ b/tests/testthat/test-read_transition_scenarios.R
@@ -136,4 +136,3 @@ test_that("with valid inputs, generate_transition_shocks generates a data frame
     n_shock_years
   )
 })
-

--- a/tests/testthat/test-run_stress_test.R
+++ b/tests/testthat/test-run_stress_test.R
@@ -18,6 +18,6 @@ test_that("output includes argument names with suffix '_arg'", {
 
   csv_files <- fs::dir_ls(out, regexp = "[.]csv$")
   data <- purrr::map(csv_files, readr::read_csv, col_types = list())
-  cols_from_arguments_have_suffix_arg <- purrr::map_lgl(data, ~rlang::has_name(.x, "term_arg"))
+  cols_from_arguments_have_suffix_arg <- purrr::map_lgl(data, ~ rlang::has_name(.x, "term_arg"))
   expect_true(all(cols_from_arguments_have_suffix_arg))
 })

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -157,7 +157,6 @@ test_that("function returns input", {
 
 # report_missings --------------------------------------------------------
 test_that("Missings are reported correctly in verbose_log_env ", {
-
   verbose_log_env()
   data <- tibble::tibble(
     a = c("A1", "A1", "A1", NA),
@@ -166,7 +165,6 @@ test_that("Missings are reported correctly in verbose_log_env ", {
   )
 
   expect_output(report_missings(data, name_data = "some"), "Counted 1 missings on column a")
-
 })
 
 test_that("Error is thrown if throw_error is TRUE", {
@@ -176,10 +174,10 @@ test_that("Error is thrown if throw_error is TRUE", {
     c = c(1, 1, 2, NaN)
   )
 
-   expect_error(
-     report_missings(data, name_data = "some", throw_error = TRUE),
-     "Missings detected on some"
-   )
+  expect_error(
+    report_missings(data, name_data = "some", throw_error = TRUE),
+    "Missings detected on some"
+  )
 })
 
 # validate_data_has_expected_cols -----------------------------------------
@@ -198,5 +196,4 @@ test_that("Error is thrown if colnames are missing", {
     ),
     "columns: D, E."
   )
-
 })

--- a/tests/testthat/test-validate.R
+++ b/tests/testthat/test-validate.R
@@ -25,7 +25,6 @@ test_that("Error is thrown if input values are of incorrect type", {
     company_exclusion = TRUE,
     asset_type = "bonds"
   ), "numeric")
-
 })
 
 test_that("Error is thrown if input values are of incorrect type for input values of length > 1", {
@@ -54,7 +53,6 @@ test_that("Error is thrown if input values are of incorrect type for input value
     company_exclusion = TRUE,
     asset_type = "bonds"
   ), "numeric")
-
 })
 
 


### PR DESCRIPTION
Loosely relates to [AB#3100](https://dev.azure.com/2DegreesInvesting/a5201d6a-87ad-4acf-b862-9cba0e1ae681/_workitems/edit/3100)

Note this works on R/, tests/, and data-raw/.

It's worth inspecting the diff because some changes
may be undesirable, for example, the readable layout
of tibble::tribble() would be broken -- to avoid that
we can use "# styler: off" and "# styler: on" around
the code we won't to omit.

﻿
