### PR TITLE
Snapshot `run_stress_test()`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,5 +47,4 @@ Desktop.ini
 *.icloud
 .Rproj.user
 docs
-tests/testthat/_snaps/run_stress_test.md
 tests/testthat/_snaps/run_stress_test*

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ Desktop.ini
 *.icloud
 .Rproj.user
 docs
+tests/testthat/_snaps/run_stress_test.md

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ Desktop.ini
 .Rproj.user
 docs
 tests/testthat/_snaps/run_stress_test.md
+tests/testthat/_snaps/run_stress_test*

--- a/R/utils-tests.R
+++ b/R/utils-tests.R
@@ -1,3 +1,20 @@
 expect_no_error <- function(object, ...) {
   testthat::expect_error(object, regexp = NA, ...)
 }
+
+#' Help skip tests where the developer has not opted in running snapshots
+#'
+#' To opt in set the environment variable `ST_OPT_IN_SNAPSHOTS = TRUE`, maybe
+#' via `usethis::edit_r_environ("project")`.
+#'
+#' @examples
+#' default <- list(ST_OPT_IN_SNAPSHOTS = FALSE)
+#' withr::with_envvar(default, testthat::skip_if_not(opt_in_snapshots()))
+#'
+#' opt_in <- list(ST_OPT_IN_SNAPSHOTS = TRUE)
+#' withr::with_envvar(opt_in, testthat::skip_if_not(opt_in_snapshots()))
+#' @noRd
+opt_in_snapshots <- function() {
+  out <- Sys.getenv("ST_OPT_IN_SNAPSHOTS", unset = "FALSE")
+  as.logical(out)
+}

--- a/tests/testthat/test-run_stress_test.R
+++ b/tests/testthat/test-run_stress_test.R
@@ -2,8 +2,8 @@ test_that("with bonds output is unchanged and names have the suffix '_arg'", {
   skip_on_ci()
   skip_on_cran()
 
-  in_agnostic <- "/home/mauro/tmp/st/ST_INPUTS_MASTER"
-  in_specific <- "/home/mauro/tmp/st/ST_TESTING_BONDS/inputs"
+  in_agnostic <- Sys.getenv("ST_AGNOSTIC")
+  in_specific <- Sys.getenv("ST_SPECIFIC_BONDS")
   out <- tempfile()
   fs::dir_create(out)
 

--- a/tests/testthat/test-run_stress_test.R
+++ b/tests/testthat/test-run_stress_test.R
@@ -1,4 +1,5 @@
 test_that("with bonds output is unchanged and names have the suffix '_arg'", {
+  skip_if_not(opt_in_snapshots())
   skip_on_ci()
   skip_on_cran()
 

--- a/tests/testthat/test-run_stress_test.R
+++ b/tests/testthat/test-run_stress_test.R
@@ -20,8 +20,6 @@ test_that("with bonds output is unchanged and names have the suffix '_arg'", {
 
   expect_snapshot(lapply(results, as.data.frame))
 
-  csv_files <- fs::dir_ls(out, regexp = "[.]csv$")
-  data <- purrr::map(csv_files, readr::read_csv, col_types = list())
-  have_suffix_arg <- purrr::map_lgl(data, ~ rlang::has_name(.x, "term_arg"))
+  have_suffix_arg <- purrr::map_lgl(results, ~ rlang::has_name(.x, "term_arg"))
   expect_true(all(have_suffix_arg))
 })

--- a/tests/testthat/test-run_stress_test.R
+++ b/tests/testthat/test-run_stress_test.R
@@ -1,6 +1,6 @@
-test_that("output includes argument names with suffix '_arg'", {
-  is_me <- identical(path.expand("~"), "/home/mauro")
-  skip_if_not(is_me)
+test_that("with bonds output is unchanged and names have the suffix '_arg'", {
+  skip_on_ci()
+  skip_on_cran()
 
   in_agnostic <- "/home/mauro/tmp/st/ST_INPUTS_MASTER"
   in_specific <- "/home/mauro/tmp/st/ST_TESTING_BONDS/inputs"
@@ -12,12 +12,15 @@ test_that("output includes argument names with suffix '_arg'", {
       input_path_project_agnostic = in_agnostic,
       input_path_project_specific = in_specific,
       output_path = out,
-      term = 1:2
+      term = 1:2,
+      return_results = TRUE
     )
   ))
 
+  expect_snapshot(x)
+
   csv_files <- fs::dir_ls(out, regexp = "[.]csv$")
   data <- purrr::map(csv_files, readr::read_csv, col_types = list())
-  cols_from_arguments_have_suffix_arg <- purrr::map_lgl(data, ~ rlang::has_name(.x, "term_arg"))
-  expect_true(all(cols_from_arguments_have_suffix_arg))
+  have_suffix_arg <- purrr::map_lgl(data, ~ rlang::has_name(.x, "term_arg"))
+  expect_true(all(have_suffix_arg))
 })

--- a/tests/testthat/test-run_stress_test.R
+++ b/tests/testthat/test-run_stress_test.R
@@ -7,8 +7,8 @@ test_that("with bonds output is unchanged and names have the suffix '_arg'", {
   out <- tempfile()
   fs::dir_create(out)
 
-  x <- suppressWarnings(capture.output(
-    run_stress_test("bonds",
+  suppressed_console_output <- suppressWarnings(capture.output(
+    results <- run_stress_test("bonds",
       input_path_project_agnostic = in_agnostic,
       input_path_project_specific = in_specific,
       output_path = out,
@@ -17,7 +17,7 @@ test_that("with bonds output is unchanged and names have the suffix '_arg'", {
     )
   ))
 
-  expect_snapshot(x)
+  expect_snapshot(lapply(results, as.data.frame))
 
   csv_files <- fs::dir_ls(out, regexp = "[.]csv$")
   data <- purrr::map(csv_files, readr::read_csv, col_types = list())


### PR DESCRIPTION
Closes [AB#3101](https://dev.azure.com/2DegreesInvesting/a5201d6a-87ad-4acf-b862-9cba0e1ae681/_workitems/edit/3101)

This PR modifies an existing test to include a snapshot of the
output of `run_stress_test()` with 'bonds' -- the same we could 
do for other asset types.

Note this now runs for everyone as long as you have environment
variables like these ones:

```
ST_AGNOSTIC="/home/mauro/tmp/st/ST_INPUTS_MASTER"
ST_SPECIFIC_BONDS="/home/mauro/tmp/st/ST_TESTING_BONDS/inputs"
```

The names are different to the ones we have been using, in part
because I think this ones are clearer, and in part to reflect
the different goal (testing) of these variables.

Note the snapshots contain just the head of the results. We could
sore more data if you choose to -- but this tiny bit is quite
useful anyway.

Note the snapshots may contain private data -- even if it's a
tiny bit. Thus I added the snapshot file to .gitignore. Each
developer will be working with their own snapshots stored locally.
This is not ideal because sometimes a snapshot does not change for
one developer but does for anotherone. Yet this seems like the
lightest weight solution that gets us a really long way in the
direction we want to go -- i.e. seems like a good start.

