### PR TITLE
reduce noise

### DIFF
--- a/web_tool_external_stress_test.R
+++ b/web_tool_external_stress_test.R
@@ -23,7 +23,7 @@ source(file.path(stress_test_path, "R", "set_paths.R"))
 source("0_web_functions.R") # This script is sourced from PACTA_analysis, so path is correct
 source(file.path(stress_test_path, "R", "stress_test_model_functions.R"))
 
-devtools::load_all()
+devtools::load_all(quiet = TRUE)
 
 ################
 # INPUT VARIABLES
@@ -61,8 +61,6 @@ if (file.exists(file.path(proc_input_path, pf_name, "total_portfolio.rda")) &
       .groups = "drop"
     ) %>%
     dplyr::ungroup()
-} else {
-  print("Insufficient Portfolio Data available. Skipping IPR stress test!")
 }
 
 
@@ -74,8 +72,6 @@ if (file.exists(file.path(results_path, pf_name, "Bonds_results_portfolio.rda"))
     dplyr::inner_join(portfolio_overview %>%
                        dplyr::filter(asset_type == "Equity"), by = c("investor_name", "portfolio_name")) %>%
     dplyr::mutate(tech_exposure = plan_carsten * portfolio_size)
-} else {
-  print("No Bonds Portfolio Data available. Skipping!")
 }
 
 if (file.exists(file.path(results_path, pf_name, "Equity_results_portfolio.rda"))) {
@@ -85,8 +81,6 @@ if (file.exists(file.path(results_path, pf_name, "Equity_results_portfolio.rda")
     dplyr::inner_join(portfolio_overview %>%
                        dplyr::filter(asset_type == "Equity"), by = c("investor_name", "portfolio_name")) %>%
     dplyr::mutate(tech_exposure = plan_carsten * portfolio_size)
-} else {
-  print("No Equity Portfolio Data available. Skipping!")
 }
 
 # load external shock data
@@ -120,8 +114,6 @@ if (exists("portfolio")) {
       loss = exposure * shock / 100,
       sector = ifelse(is.na(sector), "Other", sector)
     )
-} else {
-  print("No portfolio data -- skipping IPR stress test")
 }
 
 
@@ -131,6 +123,4 @@ if (exists("results_ipr")) {
   if (any(unique(results_ipr$sector) != "Other")) {
     results_ipr %>% readr::write_rds(file.path(results_path, pf_name, "Stress_test_results_IPR.rds"))
   }
-} else {
-  "No Stress Test results available for IPR FPS Scenario"
 }

--- a/web_tool_external_stress_test.R
+++ b/web_tool_external_stress_test.R
@@ -61,6 +61,8 @@ if (file.exists(file.path(proc_input_path, pf_name, "total_portfolio.rda")) &
       .groups = "drop"
     ) %>%
     dplyr::ungroup()
+} else {
+  write_log("Insufficient Portfolio Data available. Skipping IPR stress test!")
 }
 
 
@@ -72,6 +74,8 @@ if (file.exists(file.path(results_path, pf_name, "Bonds_results_portfolio.rda"))
     dplyr::inner_join(portfolio_overview %>%
                        dplyr::filter(asset_type == "Equity"), by = c("investor_name", "portfolio_name")) %>%
     dplyr::mutate(tech_exposure = plan_carsten * portfolio_size)
+} else {
+  write_log("No Bonds Portfolio Data available. Skipping!")
 }
 
 if (file.exists(file.path(results_path, pf_name, "Equity_results_portfolio.rda"))) {
@@ -81,6 +85,8 @@ if (file.exists(file.path(results_path, pf_name, "Equity_results_portfolio.rda")
     dplyr::inner_join(portfolio_overview %>%
                        dplyr::filter(asset_type == "Equity"), by = c("investor_name", "portfolio_name")) %>%
     dplyr::mutate(tech_exposure = plan_carsten * portfolio_size)
+} else {
+  write_log("No Equity Portfolio Data available. Skipping!")
 }
 
 # load external shock data
@@ -114,6 +120,8 @@ if (exists("portfolio")) {
       loss = exposure * shock / 100,
       sector = ifelse(is.na(sector), "Other", sector)
     )
+} else {
+  write_log("No portfolio data -- skipping IPR stress test")
 }
 
 
@@ -123,4 +131,6 @@ if (exists("results_ipr")) {
   if (any(unique(results_ipr$sector) != "Other")) {
     results_ipr %>% readr::write_rds(file.path(results_path, pf_name, "Stress_test_results_IPR.rds"))
   }
+} else {
+  write_log("No Stress Test results available for IPR FPS Scenario")
 }

--- a/web_tool_stress_test.R
+++ b/web_tool_stress_test.R
@@ -46,7 +46,7 @@ function_paths <- c(
 
 source_all(function_paths)
 
-devtools::load_all()
+devtools::load_all(quiet = TRUE)
 
 ################
 # INPUT VARIABLES
@@ -238,8 +238,6 @@ nesting_vars <- c(
 
 # the webtool should run through regardless of whether there are data for only one of the asset types or both
 if (file.exists(file.path(results_path, pf_name, paste0("Equity_results_", calculation_level, ".rda")))) {
-  print("Calculate Stress Test for Equity Portfolio")
-
   equity_path <- file.path(results_path, pf_name, paste0("Equity_results_", calculation_level, ".rda"))
 
   pacta_equity_results_full <- read_pacta_results_wt(
@@ -375,14 +373,10 @@ if (file.exists(file.path(results_path, pf_name, paste0("Equity_results_", calcu
       )
     }
   }
-} else {
-  print("No Equity Portfolio Data available. Skipping!")
 }
 
 
 if (file.exists(file.path(results_path, pf_name, paste0("Bonds_results_", calculation_level, ".rda")))) {
-  print("Calculate Stress Test for Bonds Portfolio")
-
   bonds_path <- file.path(results_path, pf_name, paste0("Bonds_results_", calculation_level, ".rda"))
 
   pacta_bonds_results_full <- read_pacta_results_wt(
@@ -516,8 +510,6 @@ if (file.exists(file.path(results_path, pf_name, paste0("Bonds_results_", calcul
       )
     }
   }
-} else {
-  print("No Bonds Portfolio Data available. Skipping!")
 }
 
 

--- a/web_tool_stress_test.R
+++ b/web_tool_stress_test.R
@@ -373,6 +373,8 @@ if (file.exists(file.path(results_path, pf_name, paste0("Equity_results_", calcu
       )
     }
   }
+} else {
+  write_log("No Equity Portfolio Data available. Skipping!")
 }
 
 
@@ -510,6 +512,8 @@ if (file.exists(file.path(results_path, pf_name, paste0("Bonds_results_", calcul
       )
     }
   }
+} else {
+  write_log("No Bonds Portfolio Data available. Skipping!")
 }
 
 


### PR DESCRIPTION
In my never-ending quest to reduce the noise in the output to the console so that it's easier to find/notice messages that actually matter, I've removed a few `print()` commands and added `quiet = TRUE` to `devtools::load_all()`