### PR TITLE
Vignette fin data

### DIFF
--- a/R/wrangle_and_check.R
+++ b/R/wrangle_and_check.R
@@ -157,7 +157,8 @@ check_financial_data <- function(financial_data, asset_type) {
 
   report_missings(
     data = financial_data,
-    name_data = "Financial Data"
+    name_data = "Financial Data",
+    throw_error = TRUE
   )
 
   report_all_duplicate_kinds(

--- a/R/wrangle_and_check.R
+++ b/R/wrangle_and_check.R
@@ -103,7 +103,7 @@ wrangle_and_check_pacta_results <- function(pacta_results, start_year, time_hori
 #' @param asset_type A string indicating if company data are for analysis for
 #'   bond or equity.
 #'
-#' @return A prewrangled `financial_data` set.
+#' @return Returns prewrangled `financial_data` invisibly.
 #' @export
 #' @examples
 #' fin_data <- tibble::tibble(
@@ -172,7 +172,7 @@ check_financial_data <- function(financial_data, asset_type) {
     asset_type = asset_type
   )
 
-  return(financial_data)
+  return(invisible(financial_data))
 }
 
 #' Check company term values for plausibility

--- a/man/check_financial_data.Rd
+++ b/man/check_financial_data.Rd
@@ -13,7 +13,7 @@ check_financial_data(financial_data, asset_type)
 bond or equity.}
 }
 \value{
-A prewrangled \code{financial_data} set.
+Returns prewrangled \code{financial_data} invisibly.
 }
 \description{
 Applies sanity checks to financial data. Also remove column

--- a/vignettes/articles/04-advanced-data-settings.Rmd
+++ b/vignettes/articles/04-advanced-data-settings.Rmd
@@ -117,6 +117,8 @@ It holds the columns:
 * `company_name`: character, holding name of analysed companies
 * `company_id`: numeric, id of company as classified by asset resolution. For
 loans workflow a placeholder value will be used.
+* `corporate_bond_ticker`: character, holding indentifier. Will be NA for loans
+workflow.
 * `pd`: numeric, holding probability of default per company. Needs to be equal
 to or larger than 0 and smaller than 1.
 * `net_profit_margin`: numeric, holding net_profit_margin per company. Needs to
@@ -126,7 +128,7 @@ company's equity value. This is the leverage. Needs to be larger than 0.
 * `volatility`: numeric, holding volatility of asset. Needs to be equal to or
 larger than 0.
 
-**NOTE**: No column may have missing values.
+**NOTE**: No column, expect for corporate_bond_ticker, may have missing values.
 
 In column `company_name` include all unique company
 names from `Loans_results_company.rda`, which you generated in [prepare loans
@@ -142,11 +144,11 @@ library(r2dii.climate.stress.test)
 loans_results_company_file_path <- file.path("/path/to/specific/data/inputs", "Loans_results_company.rda")
 validate_file_exists(loans_results_company_file_path)
 data <- readr::read_rds(loans_results_company_file_path)
-unique_companies_with_id <- data %>%
+fin_companies <- data %>%
   dplyr::select(company_name) %>%
   dplyr::distinct() %>% 
-  dplyr::mutate(company_id = 999)
-readr::write_csv(unique_companies_with_id, file.path("/some/path", "prewrangled_financial_data_stress_test.csv")) # NOTE that this will overwrite financial data currently stored at the location if available
+  dplyr::mutate(company_id = 999,   corporate_bond_ticker = NA)
+readr::write_csv(fin_companies, file.path("/some/path", "prewrangled_financial_data_stress_test.csv")) # NOTE that this will overwrite financial data currently stored at the location if available
 ```
 
 You can now open this file in a tool of your choice, and add the remaining
@@ -180,6 +182,6 @@ directories"](https://2degreesinvesting.github.io/r2dii.climate.stress.test/arti
 If the respective dataset as provided by 2DII already exists there make sure to 
 replace it with your custom file.
 
-### Running the Stress Test with provided company - term data
+### Running the Stress Test with provided financial data
 You can now run the stress test as described in vignette ["Run stress test"](https://2degreesinvesting.github.io/r2dii.climate.stress.test/articles/articles/03-run-stress-test.html).
 

--- a/vignettes/articles/04-advanced-data-settings.Rmd
+++ b/vignettes/articles/04-advanced-data-settings.Rmd
@@ -67,7 +67,8 @@ fill the gaps.
 ### Validating company - term data
 Before including the file in your analysis you may want to validate that your
 file complies with requirements concerning structure and content. You may verify
-by executing the following lines of code.
+by executing the following lines of code. You will receive warning/error
+messages in case problems are detected.
 ```{r, eval = FALSE}
 library(readr)
 library(r2dii.climate.stress.test)
@@ -141,12 +142,11 @@ library(r2dii.climate.stress.test)
 loans_results_company_file_path <- file.path("/path/to/specific/data/inputs", "Loans_results_company.rda")
 validate_file_exists(loans_results_company_file_path)
 data <- readr::read_rds(loans_results_company_file_path)
-unique_companies <- data %>%
+unique_companies_with_id <- data %>%
   dplyr::select(company_name) %>%
   dplyr::distinct() %>% 
   dplyr::mutate(company_id = NA_real_)
-readr::write_csv(unique_companies, file.path("/some/path", "prewrangled_financial_data_stress_test.csv")) # NOTE that this will overwrite financial data currently stored at the location if available
-
+readr::write_csv(unique_companies_with_id, file.path("/some/path", "prewrangled_financial_data_stress_test.csv")) # NOTE that this will overwrite financial data currently stored at the location if available
 ```
 
 You can now open this file in a tool of your choice, and add the remaining
@@ -155,7 +155,8 @@ variables. Please make sure to save the result as a csv file again.
 ### Validating financial data
 Before including the file in your analysis you may want to validate that your
 file complies with requirements concerning structure and content. You may verify
-by executing the following lines of code.
+by executing the following lines of code. You will receive warning/error
+messages in case problems are detected.
 ```{r, eval = FALSE}
 library(readr)
 library(r2dii.climate.stress.test)
@@ -163,7 +164,7 @@ library(r2dii.climate.stress.test)
 financial_data_path <- file.path("/path/to/file")
 validate_file_exists(financial_data_path)
 data <- readr::read_csv(financial_data_path)
-check_financial_data(data = data, asset_type = "loans")
+check_financial_data(financial_data = data, asset_type = "loans")
 
 ```
 

--- a/vignettes/articles/04-advanced-data-settings.Rmd
+++ b/vignettes/articles/04-advanced-data-settings.Rmd
@@ -32,8 +32,8 @@ The data that needs to be created is a csv file named `company_terms.csv`. It
 holds the columns `company_name` (character, holding name of analysed companies)
 and term (numeric, indicates which maturity the loans to respective companies is
 assumed to have in years). In column `company_name` include all unique company
-names from `Loans_results_company.rda`, which you generated in [prepare loans
-inputs](https://2degreesinvesting.github.io/r2dii.climate.stress.test/articles/articles/02-prepare-loans-inputs.html).
+names from `Loans_results_company.rda`, which you generated in ["prepare loans
+inputs"](https://2degreesinvesting.github.io/r2dii.climate.stress.test/articles/articles/02-prepare-loans-inputs.html).
 If you want to use R to obtain this column you can take the following steps.
 
 ```{r, eval = FALSE}
@@ -101,3 +101,82 @@ run_stress_test(
   use_company_terms = TRUE
 )
 ```
+
+## Financial data
+Financial data provide several financial indicators on the company level. If
+data is available you can replace our standard financial data set with a data
+set holding your financial information on the companies you included in the
+analysis.  
+
+### Preparing financial data
+The data that needs to be created is a csv file named `prewrangled_financial_data_stress_test.csv`. 
+It holds the columns:
+
+* `company_name`: character, holding name of analysed companies
+* `company_id`: numeric, id of company as classified by asset resolution. Will
+be NA for loans workflow.
+* `pd`: numeric, holding probability of default per company. Needs to be equal
+to or larger than 0 and smaller than 1.
+* `net_profit_margin`: numeric, holding net_profit_margin per company. Needs to
+be larger than 0 and equal to or smaller than 1.
+* `debt_equity_ratio`: numeric, holding ratio of outstanding debt to the
+company's equity value. This is the leverage. Needs to be larger than 0.
+* `volatility`: numeric, holding volatility of asset. Needs to be equal to or
+larger than 0.
+
+**NOTE**: Expect for `company_id` to column may have missing values.
+
+In column `company_name` include all unique company
+names from `Loans_results_company.rda`, which you generated in [prepare loans
+inputs](https://2degreesinvesting.github.io/r2dii.climate.stress.test/articles/articles/02-prepare-loans-inputs.html).
+
+If you want to use R to obtain this column you can take the following steps.
+
+```{r, eval = FALSE}
+library(readr)
+library(r2dii.climate.stress.test)
+
+loans_results_company_file_path <- file.path("/path/to/specific/data/inputs", "Loans_results_company.rda")
+validate_file_exists(loans_results_company_file_path)
+data <- readr::read_rds(loans_results_company_file_path)
+unique_companies <- data %>%
+  dplyr::select(company_name) %>%
+  dplyr::distinct() %>% 
+  dplyr::mutate(company_id = NA_real_)
+readr::write_csv(unique_companies, file.path("/some/path", "prewrangled_financial_data_stress_test.csv")) # NOTE that this will overwrite financial currently stored at the location if available
+
+```
+
+You can now open this file in a tool of your choice, and add the remaining
+variables. Please make sure to save the result as a csv file again.
+
+### Validating financial data
+Before including the file in your analysis you may want to validate that your
+file complies with requirements concerning structure and content. You may verify
+by executing the following lines of code.
+```{r, eval = FALSE}
+library(r2dii.climate.stress.test)
+
+financial_data_path <- file.path("/path/to/file")
+validate_file_exists(financial_data_path)
+data <- readr::read_csv(financial_data_path)
+validate_data_has_expected_cols(data = data, expected_columns = c("company_name", "term"))
+check_financial_data(data = data, asset_type = "loans")
+
+```
+
+### Placing file in folder structure
+In order to make sure `prewrangled_financial_data_stress_test.csv` is included
+in the analysis place it in  
+
+* `example_folder/`
+    * `inputs/`  
+    
+as set up in ["Set up project
+directories"](https://2degreesinvesting.github.io/r2dii.climate.stress.test/articles/articles/01-setup-project-directories.html).
+If the respective dataset as provided by 2DII already exists there make sure to 
+replace it with your custom file.
+
+### Running the Stress Test with provided company - term data
+You can now run the stress test as described in vignette ["Run stress test"](https://2degreesinvesting.github.io/r2dii.climate.stress.test/articles/articles/03-run-stress-test.html).
+

--- a/vignettes/articles/04-advanced-data-settings.Rmd
+++ b/vignettes/articles/04-advanced-data-settings.Rmd
@@ -172,8 +172,7 @@ In order to make sure your version
 of`prewrangled_financial_data_stress_test.csv` is used in the analysis place it
 in
 
-* `example_folder/`
-    * `inputs/`  
+* `analysis_input_files/`  
     
 as set up in ["Set up project
 directories"](https://2degreesinvesting.github.io/r2dii.climate.stress.test/articles/articles/01-setup-project-directories.html).

--- a/vignettes/articles/04-advanced-data-settings.Rmd
+++ b/vignettes/articles/04-advanced-data-settings.Rmd
@@ -148,7 +148,7 @@ data <- readr::read_rds(loans_results_company_file_path)
 fin_companies <- data %>%
   dplyr::select(company_name) %>%
   dplyr::distinct() %>% 
-  dplyr::mutate(company_id = 999,   corporate_bond_ticker = NA)
+  dplyr::mutate(company_id = 999, corporate_bond_ticker = NA)
 readr::write_csv(fin_companies, file.path("/some/path", "prewrangled_financial_data_stress_test.csv")) # NOTE that this will overwrite financial data currently stored at the location if available
 ```
 
@@ -185,4 +185,3 @@ replace it with your custom file.
 
 ### Running the Stress Test with provided financial data
 You can now run the stress test as described in vignette ["Run stress test"](https://2degreesinvesting.github.io/r2dii.climate.stress.test/articles/articles/03-run-stress-test.html).
-

--- a/vignettes/articles/04-advanced-data-settings.Rmd
+++ b/vignettes/articles/04-advanced-data-settings.Rmd
@@ -69,6 +69,7 @@ Before including the file in your analysis you may want to validate that your
 file complies with requirements concerning structure and content. You may verify
 by executing the following lines of code.
 ```{r, eval = FALSE}
+library(readr)
 library(r2dii.climate.stress.test)
 
 company_terms_path <- file.path("/path/to/file")
@@ -124,11 +125,12 @@ company's equity value. This is the leverage. Needs to be larger than 0.
 * `volatility`: numeric, holding volatility of asset. Needs to be equal to or
 larger than 0.
 
-**NOTE**: Expect for `company_id` to column may have missing values.
+**NOTE**: Except for `company_id` no column may have missing values.
 
 In column `company_name` include all unique company
 names from `Loans_results_company.rda`, which you generated in [prepare loans
 inputs](https://2degreesinvesting.github.io/r2dii.climate.stress.test/articles/articles/02-prepare-loans-inputs.html).
+Also create column company_name holding NAs.
 
 If you want to use R to obtain this column you can take the following steps.
 
@@ -143,7 +145,7 @@ unique_companies <- data %>%
   dplyr::select(company_name) %>%
   dplyr::distinct() %>% 
   dplyr::mutate(company_id = NA_real_)
-readr::write_csv(unique_companies, file.path("/some/path", "prewrangled_financial_data_stress_test.csv")) # NOTE that this will overwrite financial currently stored at the location if available
+readr::write_csv(unique_companies, file.path("/some/path", "prewrangled_financial_data_stress_test.csv")) # NOTE that this will overwrite financial data currently stored at the location if available
 
 ```
 
@@ -155,19 +157,20 @@ Before including the file in your analysis you may want to validate that your
 file complies with requirements concerning structure and content. You may verify
 by executing the following lines of code.
 ```{r, eval = FALSE}
+library(readr)
 library(r2dii.climate.stress.test)
 
 financial_data_path <- file.path("/path/to/file")
 validate_file_exists(financial_data_path)
 data <- readr::read_csv(financial_data_path)
-validate_data_has_expected_cols(data = data, expected_columns = c("company_name", "term"))
 check_financial_data(data = data, asset_type = "loans")
 
 ```
 
 ### Placing file in folder structure
-In order to make sure `prewrangled_financial_data_stress_test.csv` is included
-in the analysis place it in  
+In order to make sure your version
+of`prewrangled_financial_data_stress_test.csv` is used in the analysis place it
+in
 
 * `example_folder/`
     * `inputs/`  

--- a/vignettes/articles/04-advanced-data-settings.Rmd
+++ b/vignettes/articles/04-advanced-data-settings.Rmd
@@ -115,8 +115,8 @@ The data that needs to be created is a csv file named `prewrangled_financial_dat
 It holds the columns:
 
 * `company_name`: character, holding name of analysed companies
-* `company_id`: numeric, id of company as classified by asset resolution. Will
-be NA for loans workflow.
+* `company_id`: numeric, id of company as classified by asset resolution. For
+loans workflow a placeholder value will be used.
 * `pd`: numeric, holding probability of default per company. Needs to be equal
 to or larger than 0 and smaller than 1.
 * `net_profit_margin`: numeric, holding net_profit_margin per company. Needs to
@@ -126,14 +126,14 @@ company's equity value. This is the leverage. Needs to be larger than 0.
 * `volatility`: numeric, holding volatility of asset. Needs to be equal to or
 larger than 0.
 
-**NOTE**: Except for `company_id` no column may have missing values.
+**NOTE**: No column may have missing values.
 
 In column `company_name` include all unique company
 names from `Loans_results_company.rda`, which you generated in [prepare loans
 inputs](https://2degreesinvesting.github.io/r2dii.climate.stress.test/articles/articles/02-prepare-loans-inputs.html).
-Also create column company_name holding NAs.
+Also create column company_name holding a placeholder value, e.g. 999.
 
-If you want to use R to obtain this column you can take the following steps.
+If you want to use R to obtain this data you can take the following steps.
 
 ```{r, eval = FALSE}
 library(readr)
@@ -145,7 +145,7 @@ data <- readr::read_rds(loans_results_company_file_path)
 unique_companies_with_id <- data %>%
   dplyr::select(company_name) %>%
   dplyr::distinct() %>% 
-  dplyr::mutate(company_id = NA_real_)
+  dplyr::mutate(company_id = 999)
 readr::write_csv(unique_companies_with_id, file.path("/some/path", "prewrangled_financial_data_stress_test.csv")) # NOTE that this will overwrite financial data currently stored at the location if available
 ```
 

--- a/vignettes/articles/04-advanced-data-settings.Rmd
+++ b/vignettes/articles/04-advanced-data-settings.Rmd
@@ -128,12 +128,13 @@ company's equity value. This is the leverage. Needs to be larger than 0.
 * `volatility`: numeric, holding volatility of asset. Needs to be equal to or
 larger than 0.
 
-**NOTE**: No column, expect for corporate_bond_ticker, may have missing values.
+**NOTE**: No column, except for corporate_bond_ticker, may have missing values.
 
-In column `company_name` include all unique company
-names from `Loans_results_company.rda`, which you generated in [prepare loans
+In column `company_name` include all unique company names from
+`Loans_results_company.rda`, which you generated in [prepare loans
 inputs](https://2degreesinvesting.github.io/r2dii.climate.stress.test/articles/articles/02-prepare-loans-inputs.html).
-Also create column company_name holding a placeholder value, e.g. 999.
+Also create column `company_id` holding a placeholder value, e.g. 999, and
+column `corporate_bond_ticker`, holding NA.
 
 If you want to use R to obtain this data you can take the following steps.
 


### PR DESCRIPTION
Closes: https://dev.azure.com/2DegreesInvesting/2DegreesInvesting/_workitems/edit/3529
This PR adds a vignette for using custom financial data. 
Note: this is unnecessarily clumsy due to:

- inconsistencies in PACTA results on company_id
- using of corporate bond ticker for merges for bonds.
I would shortly review if corporate bond ticker can be omitted from financial data and the simplify the workflow if possibly, however like this we  at least provide a functioning option.
