### PR TITLE
st_read/process() now handle sector_exposure

### DIFF
--- a/R/run_stress_test.R
+++ b/R/run_stress_test.R
@@ -127,7 +127,7 @@ run_stress_test_iteration <- function(args_list) {
 
     arg_tibble_row <- arg_tibble_row %>%
       dplyr::select(-dplyr::all_of(setup_vars_lookup)) %>%
-      dplyr::rename_with( ~ paste0(.x, "_arg"))
+      dplyr::rename_with(~ paste0(.x, "_arg"))
 
     st_result <- read_and_process(arg_list_row) %>%
       purrr::map(dplyr::bind_cols, data_y = arg_tibble_row)
@@ -140,7 +140,7 @@ run_stress_test_iteration <- function(args_list) {
     dplyr::mutate(iter_var = .env$iter_var)
 
   out <- iteration_sequence(args_list) %>%
-    purrr::map(~dplyr::slice(args_tibble, .x)) %>%
+    purrr::map(~ dplyr::slice(args_tibble, .x)) %>%
     purrr::map(run_stress_test_iteration_once)
 
   return(out)

--- a/R/run_stress_test.R
+++ b/R/run_stress_test.R
@@ -345,12 +345,9 @@ iteration_sequence <- function(args_list) {
 }
 
 st_read <- function(dir, asset_type) {
-  pacta_results_path <- pacta_results_path(dir, asset_type)
-  sector_exposures_path <- file.path(dir, "overview_portfolio.rda")
-
   out <- list(
-    pacta_results = read_pacta_results(pacta_results_path),
-    sector_exposures = read_sector_exposures(sector_exposures_path)
+    pacta_results = read_pacta_results(pacta_results_file(dir, asset_type)),
+    sector_exposures = read_sector_exposures(sector_exposures_file(dir))
   )
 
   return(out)
@@ -382,11 +379,16 @@ st_process <- function(data, asset_type) {
   return(out)
 }
 
-pacta_results_path <- function(dir, asset_type) {
+pacta_results_file <- function(dir, asset_type) {
   asset_type <- stringr::str_to_title(asset_type)
   file <- glue::glue("{asset_type}_results_{calculation_level_lookup}.rda")
-  path <- file.path(dir, file)
-  return(path)
+  out <- file.path(dir, file)
+  return(out)
+}
+
+sector_exposures_file <- function(dir) {
+  out <- file.path(dir, "overview_portfolio.rda")
+  return(out)
 }
 
 get_start_year <- function(data) {

--- a/R/run_stress_test.R
+++ b/R/run_stress_test.R
@@ -171,9 +171,6 @@ read_and_process <- function(args_list) {
   cat("-- Reading input data from designated input path. \n")
   data <- st_read(input_path_project_specific, asset_type)
 
-  sector_exposures <- read_sector_exposures(file.path(input_path_project_specific, "overview_portfolio.rda")) %>%
-    process_sector_exposures(asset_type = asset_type)
-
   start_year <- get_start_year(data)
   scenarios_filter <- scenarios_filter()
 
@@ -238,7 +235,7 @@ read_and_process <- function(args_list) {
     pacta_results = pacta_results,
     capacity_factors_power = capacity_factors_power,
     excluded_companies = excluded_companies,
-    sector_exposures = sector_exposures,
+    sector_exposures = processed$sector_exposures,
     scenario_data = scenario_data,
     df_price = df_price,
     financial_data = financial_data
@@ -347,11 +344,13 @@ iteration_sequence <- function(args_list) {
   }
 }
 
-st_read <- function(input_path_project_specific, asset_type) {
-  path <- pacta_results_path(input_path_project_specific, asset_type)
+st_read <- function(dir, asset_type) {
+  pacta_results_path <- pacta_results_path(dir, asset_type)
+  sector_exposures_path <- file.path(dir, "overview_portfolio.rda")
 
   out <- list(
-    pacta_results = read_pacta_results(path)
+    pacta_results = read_pacta_results(pacta_results_path),
+    sector_exposures = read_sector_exposures(sector_exposures_path)
   )
 
   return(out)
@@ -372,8 +371,12 @@ st_process <- function(data, asset_type) {
       asset_type = asset_type
     )
 
+  sector_exposures <- data$sector_exposures %>%
+    process_sector_exposures(asset_type = asset_type)
+
   out <- list(
-    pacta_results = pacta_results
+    pacta_results = pacta_results,
+    sector_exposures = sector_exposures
   )
 
   return(out)


### PR DESCRIPTION
Relates to ab#3116
Extends #299 

This PR extends `st_read()` and `st_process()` to also handle `scenario_exposures`. 

It also adds a few minor refactorings such as renaming `*_path()` to `*_file()` and `return(something)` to `return(out)`.