### PR TITLE
update web tool script CI

### DIFF
--- a/.github/workflows/source-web-tool-scripts.yaml
+++ b/.github/workflows/source-web-tool-scripts.yaml
@@ -50,6 +50,9 @@ jobs:
           install.packages('tinytex')
           tinytex::install_tinytex()
         shell: Rscript {0}
+      - name: Install additional R pkg dependencies
+        run: install.packages('vroom')
+        shell: Rscript {0}
       - name: Source web-tool scripts
         run: |
           setwd("PACTA_analysis")


### PR DESCRIPTION
Some big changes are coming to PACTA, and in prep for that I added a dependency on `{vroom}`. This is a stopgap fix to allow the Action to run without error, because a completely new GH Action to test the web tool scripts is on its way, which will based on a completely new container, which will be aligned with a completely new Dockerfile which will package everything for the website.