### PR TITLE
use exposure from last year of prod forecast

### DIFF
--- a/R/calculate.R
+++ b/R/calculate.R
@@ -90,8 +90,11 @@ calculate_annual_profits <- function(asset_type, input_data_list, scenario_to_fo
 #'
 #' @return A tibble holding exposure_by_technology_and_company.
 calculate_exposure_by_technology_and_company <- function(asset_type,
-                                                         input_data_list, start_year,
-                                                         scenario_to_follow_ls, log_path) {
+                                                         input_data_list,
+                                                         start_year,
+                                                         time_horizon,
+                                                         scenario_to_follow_ls,
+                                                         log_path) {
   if (asset_type == "bonds") {
     subset_cols <- c("company_name", "corporate_bond_ticker", "pd")
     merge_cols <- c("company_name", "id" = "corporate_bond_ticker")
@@ -108,7 +111,7 @@ calculate_exposure_by_technology_and_company <- function(asset_type,
 
   exposure_by_technology_and_company <- input_data_list$pacta_results %>%
     dplyr::filter(
-      .data$year == .env$start_year,
+      .data$year == .env$start_year + .env$time_horizon,
       .data$scenario %in% .env$scenario_to_follow_ls
     ) %>%
     dplyr::inner_join(

--- a/R/run_stress_test.R
+++ b/R/run_stress_test.R
@@ -245,6 +245,7 @@ read_and_process <- function(args_list) {
     asset_type = asset_type,
     input_data_list = input_data_list,
     start_year = start_year,
+    time_horizon = time_horizon_lookup,
     scenario_to_follow_ls = shock_scenario_lookup,
     log_path = log_path
   )

--- a/man/calculate_exposure_by_technology_and_company.Rd
+++ b/man/calculate_exposure_by_technology_and_company.Rd
@@ -8,6 +8,7 @@ calculate_exposure_by_technology_and_company(
   asset_type,
   input_data_list,
   start_year,
+  time_horizon,
   scenario_to_follow_ls,
   log_path
 )
@@ -18,6 +19,8 @@ calculate_exposure_by_technology_and_company(
 \item{input_data_list}{List with project agnostic and project specific input data}
 
 \item{start_year}{Numeric, holding start year of analysis.}
+
+\item{time_horizon}{Considered timeframe for PACTA analysis.}
 
 \item{scenario_to_follow_ls}{Character. A string that indicates which
 of the scenarios included in the analysis should be used to set the


### PR DESCRIPTION
preparation for tmsr/smsp fix

This PR:
- uses the last year of the production forecast to derive company/technology level exposures.
- any company for which the production share within their ald_sector changes over that time frame will have a different overall loss. However the percentage change on company_technology level should remain the same