### PR TITLE
rename output columns

### DIFF
--- a/R/stress_test_model_functions.R
+++ b/R/stress_test_model_functions.R
@@ -101,7 +101,8 @@ dcf_model_techlevel <- function(data, discount_rate) {
       discounted_net_profit_baseline = net_profits_baseline / (1 + discount_rate)^t_calc,
       discounted_net_profit_ls = net_profits_ls / (1 + discount_rate)^t_calc
     ) %>%
-    dplyr::select(-t_calc)
+    dplyr::select(-t_calc) %>%
+    dplyr::ungroup()
 }
 
 # run basic portfolio data consistency checks that are required for further data processing

--- a/R/wrangle_and_check.R
+++ b/R/wrangle_and_check.R
@@ -339,6 +339,26 @@ wrangle_results <- function(results_list, sensitivity_analysis_vars) {
       .data$analysed_sectors_value_change, .data$portfolio_aum,
       .data$portfolio_value_change_perc, .data$portfolio_value_change,
       .data$exclude, !!!rlang::syms(sensitivity_analysis_vars)
+    ) %>%
+    dplyr::rename(
+      company_technology_exposure = .data$tech_company_exposure,
+      company_technology_percent_value_change = .data$VaR_tech_company,
+      company_technology_absolute_value_change = .data$tech_company_value_change,
+      company_exposure = .data$company_exposure,
+      company_percent_value_change = .data$VaR_company,
+      company_absolute_value_change = .data$company_value_change,
+      technology_exposure = .data$technology_exposure,
+      technology_percent_value_change = .data$VaR_technology,
+      technology_absolute_value_change = .data$technology_value_change,
+      sector_exposure = .data$sector_exposure,
+      sector_percent_value_change = .data$VaR_sector,
+      sector_absolute_value_change = .data$sector_value_change,
+      analysed_portfolio_exposure = .data$analysed_sectors_exposure,
+      analysed_portfolio_percent_value_change = .data$VaR_analysed_sectors,
+      analysed_portfolio_absolute_value_change = .data$analysed_sectors_value_change,
+      total_portfolio_exposure = .data$portfolio_aum,
+      total_portfolio_percent_value_change = .data$portfolio_value_change_perc,
+      total_portfolio_absolute_value_change = .data$portfolio_value_change
     )
 
   portfolio_value_changes <- results_list$company_value_changes %>%
@@ -359,7 +379,21 @@ wrangle_results <- function(results_list, sensitivity_analysis_vars) {
     # ADO 2549 - all numeric variables should be unique across the CUC variables
     # running distinct all and the check afterwards ensures this is the case
     dplyr::distinct_all() %>%
-    dplyr::arrange(.data$year_of_shock, .data$ald_sector, .data$technology)
+    dplyr::arrange(.data$year_of_shock, .data$ald_sector, .data$technology) %>%
+    dplyr::rename(
+      technology_exposure = .data$technology_exposure,
+      technology_percent_value_change = .data$VaR_technology,
+      technology_absolute_value_change = .data$technology_value_change,
+      sector_exposure = .data$sector_exposure,
+      sector_percent_value_change = .data$VaR_sector,
+      sector_absolute_value_change = .data$sector_value_change,
+      analysed_portfolio_exposure = .data$analysed_sectors_exposure,
+      analysed_portfolio_percent_value_change = .data$VaR_analysed_sectors,
+      analysed_portfolio_absolute_value_change = .data$analysed_sectors_value_change,
+      total_portfolio_exposure = .data$portfolio_aum,
+      total_portfolio_percent_value_change = .data$portfolio_value_change_perc,
+      total_portfolio_absolute_value_change = .data$portfolio_value_change
+    )
 
   # expected loss -----------------------------------------------------------
   company_expected_loss <- results_list$company_expected_loss %>%
@@ -373,6 +407,11 @@ wrangle_results <- function(results_list, sensitivity_analysis_vars) {
     dplyr::arrange(
       .data$scenario_geography, .data$scenario_name, .data$investor_name,
       .data$portfolio_name, .data$company_name, .data$ald_sector
+    ) %>%
+    dplyr::rename(
+      pd_baseline = .data$pd,
+      pd_change_shock = .data$PD_change,
+      expected_loss_shock = .data$expected_loss_late_sudden
     )
 
   # pd changes --------------------------------------------------------------
@@ -385,6 +424,9 @@ wrangle_results <- function(results_list, sensitivity_analysis_vars) {
     dplyr::arrange(
       .data$scenario_geography, .data$scenario_name, .data$investor_name,
       .data$portfolio_name, .data$company_name, .data$ald_sector, .data$year
+    ) %>%
+    dplyr::rename(
+      pd_change_shock = .data$PD_change
     )
 
   sector_pd_changes_annual <- results_list$company_pd_changes_annual %>%
@@ -402,17 +444,23 @@ wrangle_results <- function(results_list, sensitivity_analysis_vars) {
     dplyr::arrange(
       .data$scenario_geography, .data$scenario_name, .data$investor_name,
       .data$portfolio_name, .data$ald_sector, .data$year
+    ) %>%
+    dplyr::rename(
+      pd_change_shock = .data$PD_change
     )
 
   company_pd_changes_overall <- results_list$company_pd_changes_overall %>%
     dplyr::select(
       .data$scenario_name, .data$scenario_geography, .data$investor_name,
-      .data$portfolio_name, .data$company_name, .data$ald_sector, .data$term, .data$PD_change,
-      !!!rlang::syms(sensitivity_analysis_vars)
+      .data$portfolio_name, .data$company_name, .data$ald_sector, .data$term,
+      .data$PD_change, !!!rlang::syms(sensitivity_analysis_vars)
     ) %>%
     dplyr::arrange(
       .data$scenario_geography, .data$scenario_name, .data$investor_name,
       .data$portfolio_name, .data$company_name, .data$ald_sector, .data$term
+    ) %>%
+    dplyr::rename(
+      pd_change_shock = .data$PD_change
     )
 
   sector_pd_changes_overall <- results_list$company_pd_changes_overall %>%
@@ -430,11 +478,29 @@ wrangle_results <- function(results_list, sensitivity_analysis_vars) {
     dplyr::arrange(
       .data$scenario_geography, .data$scenario_name, .data$investor_name,
       .data$portfolio_name, .data$ald_sector, .data$term
+    ) %>%
+    dplyr::rename(
+      pd_change_shock = .data$PD_change
     )
 
   # company trajectories ----------------------------------------------------
   company_trajectories <- results_list$company_trajectories %>%
-    dplyr::rename(baseline_price = Baseline_price)
+    dplyr::rename(
+      production_plan_company_technology = .data$plan_tech_prod,
+      # TODO: add once ADO3530 is merged
+      # direction_of_target = .data$direction,
+      production_baseline_scenario = .data$baseline,
+      production_target_scenario = .data$scen_to_follow_aligned,
+      production_shock_scenario = .data$late_sudden,
+      production_change_target_scenario = .data$scenario_change_aligned,
+      production_unit = .data$sector_unit_ds,
+      price_baseline_scenario = .data$Baseline_price,
+      price_shock_scenario = .data$late_sudden_price,
+      net_profits_baseline_scenario = .data$net_profits_baseline,
+      net_profits_shock_scenario = .data$net_profits_ls,
+      discounted_net_profits_baseline_scenario = .data$discounted_net_profit_baseline,
+      discounted_net_profits_shock_scenario = .data$discounted_net_profit_ls
+    )
 
   return(list(
     company_value_changes = company_value_changes,

--- a/R/wrangle_and_check.R
+++ b/R/wrangle_and_check.R
@@ -627,7 +627,7 @@ check_results <- function(wrangled_results_list, sensitivity_analysis_vars) {
     ) %>%
     report_all_duplicate_kinds(
       composite_unique_cols = c(
-        "investor_name", "portfolio_name", "id", "company_name", "year",
+        "investor_name", "portfolio_name", "company_name", "year",
         "scenario_geography", "ald_sector", "technology", sensitivity_analysis_vars
       )
     )

--- a/R/wrangle_and_check.R
+++ b/R/wrangle_and_check.R
@@ -485,6 +485,19 @@ wrangle_results <- function(results_list, sensitivity_analysis_vars) {
 
   # company trajectories ----------------------------------------------------
   company_trajectories <- results_list$company_trajectories %>%
+    dplyr::select(
+      .data$investor_name, .data$portfolio_name, .data$scenario_name, .data$id,
+      .data$company_name, .data$year, .data$scenario_geography, .data$ald_sector,
+      .data$technology, .data$plan_tech_prod, .data$phase_out, .data$baseline,
+      .data$scen_to_follow_aligned,	.data$late_sudden,
+      .data$scenario_change_aligned, .data$company_id, .data$pd,
+      .data$net_profit_margin, .data$debt_equity_ratio, .data$volatility,
+      .data$sector_unit_ds, .data$price_unit_iea, .data$price_unit_etr,
+      .data$Baseline_price, .data$baseline_source, .data$late_sudden_price,
+      .data$net_profits_baseline, .data$net_profits_ls,
+      .data$discounted_net_profit_baseline, .data$discounted_net_profit_ls,
+      !!!rlang::syms(sensitivity_analysis_vars)
+    ) %>%
     dplyr::rename(
       production_plan_company_technology = .data$plan_tech_prod,
       # TODO: add once ADO3530 is merged

--- a/R/wrangle_and_check.R
+++ b/R/wrangle_and_check.R
@@ -486,17 +486,16 @@ wrangle_results <- function(results_list, sensitivity_analysis_vars) {
   # company trajectories ----------------------------------------------------
   company_trajectories <- results_list$company_trajectories %>%
     dplyr::select(
-      .data$investor_name, .data$portfolio_name, .data$scenario_name, .data$id,
+      .data$investor_name, .data$portfolio_name, .data$scenario_name,
       .data$company_name, .data$year, .data$scenario_geography, .data$ald_sector,
       .data$technology, .data$plan_tech_prod, .data$phase_out, .data$baseline,
-      .data$scen_to_follow_aligned,	.data$late_sudden,
+      .data$scen_to_follow_aligned, .data$late_sudden,
       .data$scenario_change_aligned, .data$company_id, .data$pd,
       .data$net_profit_margin, .data$debt_equity_ratio, .data$volatility,
       .data$sector_unit_ds, .data$price_unit_iea, .data$price_unit_etr,
-      .data$Baseline_price, .data$baseline_source, .data$late_sudden_price,
-      .data$net_profits_baseline, .data$net_profits_ls,
-      .data$discounted_net_profit_baseline, .data$discounted_net_profit_ls,
-      !!!rlang::syms(sensitivity_analysis_vars)
+      .data$Baseline_price, .data$late_sudden_price, .data$net_profits_baseline,
+      .data$net_profits_ls, .data$discounted_net_profit_baseline,
+      .data$discounted_net_profit_ls, !!!rlang::syms(sensitivity_analysis_vars)
     ) %>%
     dplyr::rename(
       production_plan_company_technology = .data$plan_tech_prod,

--- a/vignettes/articles/05-read-the-outputs.Rmd
+++ b/vignettes/articles/05-read-the-outputs.Rmd
@@ -98,58 +98,60 @@ and the end year of the analysis.
 line with the technologies, for which the scenarios provide production pathways.
 * `asset_portfolio_value`: Value of all holdings of the given asset type in the
 analysed portfolio.
-* `tech_company_exposure`: Exposure of the portfolio or loan book to the
+* `company_technology_exposure`: Exposure of the portfolio or loan book to the
 company_technology level. This is approximated by multiplying the company
 production technology share with the overall company exposure.
-* `VaR_tech_company`: Relative potential value change due to the policy shock on
-the company-technology level for the portfolio or loan book at hand. Value in
-percentage points, i.e. a value of -2.5 indicates a potential loss of 2.5%
-points for the given combination.
-* `tech_company_value_change`: Potential absolute value change of the portfolio
-or loan book on the company-technology level indicated. Calculated as
-`tech_company_exposure * VaR_tech_company`.
+* `company_technology_percent_value_change`: Relative potential value change due
+to the policy shock on the company-technology level for the portfolio or loan
+book at hand. Value in percentage points, i.e. a value of -2.5 indicates a
+potential loss of 2.5% points for the given combination.
+* `company_technology_absolute_value_change`: Potential absolute value change of
+the portfolio or loan book on the company-technology level indicated.
+Calculated as `company_technology_exposure * company_technology_absolute_value_change`.
 * `company_exposure`: Exposure of the portfolio or loan book to the
 company indicated.
-* `VaR_company`: Relative potential value change due to the policy shock on
-the company level for the portfolio or loan book at hand. Value in percentage
-points.
-* `company_value_change`: Potential absolute value change of the portfolio or
-loan book on the company level indicated. Calculated as
-`company_exposure * VaR_company`.
+* `company_percent_value_change`: Relative potential value change due to the
+policy shock on the company level for the portfolio or loan book at hand. Value
+in percentage points.
+* `company_absolute_value_change`: Potential absolute value change of the
+portfolio or loan book on the company level indicated. Calculated as
+`company_exposure * company_percent_value_change`.
 * `technology_exposure`: Exposure of the portfolio or loan book to the
 technology indicated. This is an aggregate of the technology exposure across all
 companies with production in the given technology.
-* `VaR_technology`: Relative potential value change of the sub sector indicated
-by the technology across all companies with production in the given technology.
-Value in percentage points.
-* `technology_value_change`: Potential absolute value change of the portfolio or
-loan book on the technology level indicated. Calculated as
-`technology_exposure * VaR_technology`.
+* `technology_percent_value_change`: Relative potential value change of the sub
+sector indicated by the technology across all companies with production in the
+given technology. Value in percentage points.
+* `technology_absolute_value_change`: Potential absolute value change of the
+portfolio or loan book on the technology level indicated. Calculated as
+`technology_exposure * technology_percent_value_change`.
 * `sector_exposure`: Exposure of the portfolio or loan book to the sector
 indicated. This is an aggregate of the sector exposure across all companies with
 production in the given sector.
-* `VaR_sector`: Relative potential value change of the sector indicated across
-all companies with production in the given sector. Value in percentage points.
-* `sector_value_change`: Potential absolute value change of the portfolio or
-loan book on the sector level indicated. Calculated as
-`sector_exposure * VaR_sector`.
-* `analysed_sectors_exposure`: Exposure of the portfolio or loan book to all
+* `sector_percent_value_change`: Relative potential value change of the sector
+indicated across all companies with production in the given sector. Value in
+percentage points.
+* `sector_absolute_value_change`: Potential absolute value change of the
+portfolio or loan book on the sector level indicated. Calculated as
+`sector_exposure * sector_percent_value_change`.
+* `analysed_portfolio_exposure`: Exposure of the portfolio or loan book to all
 sectors in scope of the analysis. This is an aggregate of the exposure across
 all companies with production in the sectors that are in scope.
-* `VaR_analysed_sectors`: Relative potential value change of portfolio or loan
-book across all companies with production in the in-scope sectors. Value in
-percentage points.
-* `analysed_sectors_value_change`: Potential absolute value change of the
-portfolio or loan book on the level of in scope sectors. Calculated as
-`analysed_sectors_exposure * VaR_analysed_sectors`.
-* `portfolio_aum`: Total absolute value of the assets under management for the
-given asset type.
-* `portfolio_value_change_perc`: Relative potential value change of portfolio or
-loan book across all companies relative to the total portfolio value. Note that
-this does not cover potential losses for companies operating in sectors that are
-out of scope. Value in percentage points.
-* `portfolio_value_change`: Potential absolute value change of the portfolio or
-loan book. Calculated as `portfolio_aum * portfolio_value_change_perc`.
+* `analysed_portfolio_percent_value_change`: Relative potential value change of
+portfolio or loan book across all companies with production in the in-scope
+sectors. Value in percentage points.
+* `analysed_portfolio_absolute_value_change`: Potential absolute value change of
+the portfolio or loan book on the level of in scope sectors. Calculated as
+`analysed_portfolio_exposure * analysed_portfolio_percent_value_change`.
+* `total_portfolio_exposure`: Total absolute value of the assets under
+management for the given asset type.
+* `total_portfolio_percent_value_change`: Relative potential value change of
+portfolio or loan book across all companies relative to the total portfolio
+value. Note that this does not cover potential losses for companies operating in
+sectors that are out of scope. Value in percentage points.
+* `total_portfolio_absolute_value_change`: Potential absolute value change of
+the portfolio or loan book. Calculated as
+`total_portfolio_exposure * total_portfolio_percent_value_change`.
 * `exclude`: Logical indicator that shows if the given combination of company
 and technology was excluded from the shock because the production forecast
 indicated a phase out in production.
@@ -178,12 +180,13 @@ used.
 or bank for which the analysis was run.
 * `company_name`: Name of the company that was analyzed.
 * `ald_sector`: Sector of the production assets analyzed.
-* `pd`: Starting point probability of default for loans to the given company in
-the loan book in percentage points.
-* `PD_change`: Change in probability of default of the given company, based on
-the Merton credit risk model and a climate transition policy shock as indicated.
-in `scenario_name`. In percentage points. Notice: A positive number indicates
-the probability of default increases, hence the expected loss also increases.
+* `pd_baseline`: Starting point probability of default for loans to the given
+company in the loan book in percentage points.
+* `pd_change_shock`: Change in probability of default of the given company,
+based on the Merton credit risk model and a climate transition policy shock as
+indicated in `scenario_name`. In percentage points. Notice: A positive number
+indicates the probability of default increases, hence the expected loss also
+increases.
 * `lgd`: Loss given default applied in the calculation of the expected loss.
 Depending on which asset type was analyzed, this will reflect the setting of
 either `lgd_senior_claims_arg` or `lgd_subordinated_claims_arg`. For corporate
@@ -194,14 +197,33 @@ loans (or alternatively of the credit limit) to a company.
 * `expected_loss_baseline`: The expected loss of the holdings of a company in
 the analyzed portfolio or loan book based on the exposure to that company under
 a baseline (commonly business as usual) scenario. This is calculated as:
-`pd * lgd * exposure_at_default`.
-* `expected_loss_late_sudden`: The expected loss of the holdings of a company in
+`pd_baseline * lgd * exposure_at_default`.
+* `expected_loss_shock`: The expected loss of the holdings of a company in
 the analyzed portfolio or loan book based on the exposure to that company under
 a shock scenario (here: a late and sudden climate transition policy). This is
-calculated as: `(pd + PD_change) * lgd * exposure_at_default`.
+calculated as: `(pd_baseline + pd_change_shock) * lgd * exposure_at_default`.
 
 ### loans_company_pd_changes_annual_\<suffix\>
-To be continued.
+
+This file contains an overview on the company level of how annual probabilities
+of default change relative to the baseline scenario after the shock year.
+
+* `scenario_name`: Name that highlights the use of the Carbon budget.
+compensation mechanism and the Year of the introduction of a transition policy.
+* `scenario_geography`: Region for which the analysis was run. This refers to
+the location of assets considered as well as the regionality of scenario targets
+used.
+* `investor_name`: Name of the investor or bank for which the analysis was run.
+* `portfolio_name`: Name of the portfolio or loan book managed by the investor
+or bank for which the analysis was run.
+* `company_name`: Name of the company that was analyzed.
+* `ald_sector`: Sector of the production assets analyzed.
+* `year`: Calendar year.
+* `pd_change_shock`: Change in probability of default of the the companies in
+the portfolio or loan book. This PD change assumes a loan of one year maturity
+at the point in time indicated by `year`. Specifically, it shows how the
+probability of default of such a loan that is rolled over every year after the
+policy shock will change over time.
 
 ### loans_sector_pd_changes_annual_\<suffix\>
 
@@ -218,14 +240,30 @@ used.
 or bank for which the analysis was run.
 * `ald_sector`: Sector of the production assets analyzed.
 * `year`: Calendar year.
-* `PD_change`: Change in probability of default of the the companies in the
-portfolio or loan book, aggregated to the sector level. This PD change assumes a
-loan of one year maturity at the point in time indicated by `year`.
+* `pd_change_shock`: Change in probability of default of the the companies in
+the portfolio or loan book, aggregated to the sector level. This PD change
+assumes a loan of one year maturity at the point in time indicated by `year`.
 Specifically, it shows how the probability of default of such a loan that is
 rolled over every year after the policy shock will change over time.
 
-### loans_sector_pd_changes_overall_\<suffix\>
-To be continued.
+### loans_company_pd_changes_overall_\<suffix\>
+
+This file contains an overview on the company level of how overall probabilities
+of default change depending on the maturities of the underlying loans.
+
+* `scenario_name`: Name that highlights the use of the Carbon budget.
+* `scenario_geography`: Region for which the analysis was run. This refers to
+the location of assets considered as well as the regionality of scenario targets
+used.
+* `investor_name`: Name of the investor or bank for which the analysis was run.
+* `portfolio_name`: Name of the portfolio or loan book managed by the investor
+or bank for which the analysis was run.
+* `company_name`: Name of the company that was analyzed.
+* `ald_sector`: Sector of the production assets analyzed.
+* `term`: Years to maturity of the loans.
+* `pd_change_shock`: Change in probability of default of the the companies in
+the portfolio or loan book. This PD change shows the variation of the impact on
+PDs by different maturities on the sector level.
 
 ### loans_sector_pd_changes_overall_\<suffix\>
 
@@ -241,9 +279,9 @@ used.
 or bank for which the analysis was run.
 * `ald_sector`: Sector of the production assets analyzed.
 * `term`: Years to maturity of the loans.
-* `PD_change`: Change in probability of default of the the companies in the
-portfolio or loan book, aggregated to the sector level. This PD change shows
-variation of the impact on PDs by different maturities on the sector level.
+* `pd_change_shock`: Change in probability of default of the the companies in
+the portfolio or loan book, aggregated to the sector level. This PD change shows
+the variation of the impact on PDs by different maturities on the sector level.
 
 
 ### company_trajectories_\<suffix\>

--- a/vignettes/articles/05-read-the-outputs.Rmd
+++ b/vignettes/articles/05-read-the-outputs.Rmd
@@ -209,7 +209,7 @@ This file contains an overview on the company level of how annual probabilities
 of default change relative to the baseline scenario after the shock year.
 
 * `scenario_name`: Name that highlights the use of the Carbon budget.
-compensation mechanism and the Year of the introduction of a transition policy.
+compensation mechanism and the year of the introduction of a transition policy.
 * `scenario_geography`: Region for which the analysis was run. This refers to
 the location of assets considered as well as the regionality of scenario targets
 used.
@@ -293,7 +293,6 @@ company-technology level for the baseline and the shock scenarios.
 * `portfolio_name`: Name of the portfolio or loan book managed by the investor
 or bank for which the analysis was run.
 * `scenario_name`: Name that highlights the use of the Carbon budget.
-* `id`: internal id related to the company in the loan book or portfolio
 * `company_name`: Name of the company that was analyzed.
 * `year`: Calendar year.
 * `scenario_geography`: Region for which the analysis was run. This refers to
@@ -329,7 +328,6 @@ scenarios.
 scenarios.
 * `price_baseline_scenario`: Market price for the given year and technology
 under the baseline scenario.
-* `baseline_source`: Source of the baseline scenario.
 * `price_shock_scenario`: Market price for the given year and technology under
 the shock scenario.
 * `net_profits_baseline_scenario`: Annual projected net profits of the given

--- a/vignettes/articles/05-read-the-outputs.Rmd
+++ b/vignettes/articles/05-read-the-outputs.Rmd
@@ -285,4 +285,60 @@ the variation of the impact on PDs by different maturities on the sector level.
 
 
 ### company_trajectories_\<suffix\>
-To be continued.
+
+This file contains an in detail overview of cash flow projections on the 
+company-technology level for the baseline and the shock scenarios.
+
+* `investor_name`: Name of the investor or bank for which the analysis was run.
+* `portfolio_name`: Name of the portfolio or loan book managed by the investor
+or bank for which the analysis was run.
+* `scenario_name`: Name that highlights the use of the Carbon budget.
+* `id`: internal id related to the company in the loan book or portfolio
+* `company_name`: Name of the company that was analyzed.
+* `year`: Calendar year.
+* `scenario_geography`: Region for which the analysis was run. This refers to
+the location of assets considered as well as the regionality of scenario targets
+used.
+* `ald_sector`: Sector of the production assets analyzed.
+* `technology`: The technology can be understood as a sub sector. These must be
+in line with the technologies, for which the scenarios provide production
+pathways.
+* `production_plan_company_technology`: Five year forward looking production
+plans, by company, technology and year.
+* `phase_out`: Logical indicator, showing if the given company phases out its
+production of the indicated technology during the production forecast period.
+* `production_baseline_scenario`: Production plan for the combination of company
+and technology under the baseline scenario.
+* `production_target_scenario`: Production plan for the combination of company
+and technology under the target scenario.
+* `production_shock_scenario`: Production plan for the combination of company
+and technology under the shock scenario.
+* `production_change_target_scenario`: Year by year required absolute changes of
+production for the combination of company and technology under the target
+scenario.
+* `company_id`: Internal company identifier.
+* `pd`: Probability of default under the baseline scenario.
+* `net_profit_margin`: Net profit margin of the company.
+* `debt_equity_ratio`: Debt to equity ratio of the company.
+* `volatility`: Volatility of the asset price of the company.
+* `production_unit`: Unit of the real production associated with the given
+combination of company and technology.
+* `price_unit_iea`: Unit of the market price for the given technology for IEA
+scenarios.
+* `price_unit_etr`: Unit of the market price for the given technology for ETR
+scenarios.
+* `price_baseline_scenario`: Market price for the given year and technology
+under the baseline scenario.
+* `baseline_source`: Source of the baseline scenario.
+* `price_shock_scenario`: Market price for the given year and technology under
+the shock scenario.
+* `net_profits_baseline_scenario`: Annual projected net profits of the given
+combination of company and technology under the baseline scenario.
+* `net_profits_shock_scenario`: Annual projected net profits of the given
+combination of company and technology under the shock scenario.
+* `discounted_net_profits_baseline_scenario`: Annual projected discounted net
+profits of the given combination of company and technology under the baseline
+scenario.
+* `discounted_net_profits_shock_scenario`: Annual projected discounted net
+profits of the given combination of company and technology under the shock
+scenario.


### PR DESCRIPTION
closes ADO 3126

This PR:
- renames the columns in the output files to more understandable terminology
- updates the vignettes
- remove hard coded scenario specific columns form trajectory output (SDS, NPS....)