### PR TITLE
allow manual rebuild and do not rebuild on tags

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -3,7 +3,7 @@
 on:
   push:
     branches: [main, master]
-    tags: ['*']
+    workflow_dispatch:
 
 name: pkgdown
 


### PR DESCRIPTION
Avoid rebuilding of vignettes when tags are pushed for PACTA releases and add option to manually rebuild.