### PR TITLE
return exposure weighted aggregate credit results

### DIFF
--- a/R/calculate_annual_pd_changes.R
+++ b/R/calculate_annual_pd_changes.R
@@ -11,21 +11,22 @@
 #' only after the shock, we get diverging starting points.
 #'
 #' @param data A dataframe containing the (discounted) annual profits
+#' @param exposure_at_default A dataframe that contains the share of the
+#'   portfolio value of each company-technology combination. Used to quantify
+#'   the impact of the company-tech level shock on higher levels of aggregation
+#'   in the portfolio
 #' @param shock_year A numeric vector of length one that indicates in which year
 #'   the policy shock strikes in a given scenario
 #' @param end_of_analysis A numeric vector of length one that indicates until
 #'   which year the analysis runs
 #' @param risk_free_interest_rate A numeric vector of length one that indicates
 #'   the risk free rate of interest
-#' @param exposure_at_default A dataframe that contains the share of the
-#'   portfolio value of each company-technology combination. Used to quantify
-#'   the impact of the company-tech level shock on higher levels of aggregation
-#'   in the portfolio
+
 calculate_pd_change_annual <- function(data,
+                                       exposure_at_default,
                                        shock_year = NULL,
                                        end_of_analysis = NULL,
-                                       risk_free_interest_rate = NULL,
-                                       exposure_at_default = NULL) {
+                                       risk_free_interest_rate = NULL) {
   force(data)
   shock_year %||% stop("Must provide input for 'shock_year'", call. = FALSE)
   end_of_analysis %||% stop("Must provide input for 'end_of_analysis'", call. = FALSE)

--- a/R/calculate_overall_pd_changes.R
+++ b/R/calculate_overall_pd_changes.R
@@ -13,10 +13,15 @@
 #'   which year the analysis runs
 #' @param risk_free_interest_rate A numeric vector of length one that indicates
 #'   the risk free rate of interest
+#' @param exposure_at_default A dataframe that contains the share of the
+#'   portfolio value of each company-technology combination. Used to quantify
+#'   the impact of the company-tech level shock on higher levels of aggregation
+#'   in the portfolio
 calculate_pd_change_overall <- function(data,
                                         shock_year = NULL,
                                         end_of_analysis = NULL,
-                                        risk_free_interest_rate = NULL) {
+                                        risk_free_interest_rate = NULL,
+                                        exposure_at_default = NULL) {
   force(data)
   shock_year %||% stop("Must provide input for 'shock_year'", call. = FALSE)
   end_of_analysis %||% stop("Must provide input for 'end_of_analysis'", call. = FALSE)
@@ -29,6 +34,15 @@ calculate_pd_change_overall <- function(data,
       "scenario_geography", "ald_sector", "technology",
       "scenario_name", "discounted_net_profit_ls",
       "discounted_net_profit_baseline", "debt_equity_ratio", "volatility"
+    )
+  )
+
+  validate_data_has_expected_cols(
+    data = exposure_at_default,
+    expected_columns = c(
+      "investor_name", "portfolio_name", "company_name", "year",
+      "scenario_geography", "ald_sector", "technology",
+      "plan_carsten", "plan_sec_carsten", "term", "pd"
     )
   )
 
@@ -94,6 +108,40 @@ calculate_pd_change_overall <- function(data,
       PD_late_sudden = 1 - .data$Survival_late_sudden,
       PD_change = .data$PD_late_sudden - .data$PD_baseline
     )
+
+  exposure_at_default <- exposure_at_default %>%
+    # distinct in order to remove unused technology level information, the
+    # trivial year and the unneeded financial info
+    dplyr::distinct(
+      .data$investor_name, .data$portfolio_name, .data$company_name,
+      .data$ald_sector, .data$scenario_geography, .data$plan_sec_carsten
+    )
+
+  #TODO: needs a check which lines have been removed
+  results <- results %>%
+    dplyr::inner_join(
+      exposure_at_default,
+      by = c("investor_name", "portfolio_name", "company_name",
+             "scenario_geography", "ald_sector")
+    )
+
+  results <- results %>%
+    dplyr::group_by(
+      .data$investor_name, .data$portfolio_name, .data$ald_sector,
+      .data$scenario_geography, .data$term
+    ) %>%
+    dplyr::mutate(
+      PD_baseline_sector = stats::weighted.mean(
+        .data$PD_baseline, w = .data$plan_sec_carsten, na.rm = TRUE
+      ),
+      PD_late_sudden_sector = stats::weighted.mean(
+        .data$PD_late_sudden, w = .data$plan_sec_carsten, na.rm = TRUE
+      ),
+      PD_change_sector = stats::weighted.mean(
+        .data$PD_change, w = .data$plan_sec_carsten, na.rm = TRUE
+      )
+    ) %>%
+    dplyr::ungroup()
 
   return(results)
 }

--- a/R/calculate_overall_pd_changes.R
+++ b/R/calculate_overall_pd_changes.R
@@ -7,21 +7,21 @@
 #' level.
 #'
 #' @param data A dataframe containing the (discounted) annual profits
+#' @param exposure_at_default A dataframe that contains the share of the
+#'   portfolio value of each company-technology combination. Used to quantify
+#'   the impact of the company-tech level shock on higher levels of aggregation
+#'   in the portfolio
 #' @param shock_year A numeric vector of length one that indicates in which year
 #'   the policy shock strikes in a given scenario
 #' @param end_of_analysis A numeric vector of length one that indicates until
 #'   which year the analysis runs
 #' @param risk_free_interest_rate A numeric vector of length one that indicates
 #'   the risk free rate of interest
-#' @param exposure_at_default A dataframe that contains the share of the
-#'   portfolio value of each company-technology combination. Used to quantify
-#'   the impact of the company-tech level shock on higher levels of aggregation
-#'   in the portfolio
 calculate_pd_change_overall <- function(data,
+                                        exposure_at_default,
                                         shock_year = NULL,
                                         end_of_analysis = NULL,
-                                        risk_free_interest_rate = NULL,
-                                        exposure_at_default = NULL) {
+                                        risk_free_interest_rate = NULL) {
   force(data)
   shock_year %||% stop("Must provide input for 'shock_year'", call. = FALSE)
   end_of_analysis %||% stop("Must provide input for 'end_of_analysis'", call. = FALSE)

--- a/R/run_stress_test.R
+++ b/R/run_stress_test.R
@@ -271,7 +271,8 @@ read_and_process_and_calc <- function(args_list) {
     calculate_pd_change_overall(
       shock_year = transition_scenario$year_of_shock,
       end_of_analysis = end_year_lookup,
-      risk_free_interest_rate = risk_free_rate
+      risk_free_interest_rate = risk_free_rate,
+      exposure_at_default = exposure_by_technology_and_company
     )
 
   # TODO: ADO 879 - note which companies produce missing results due to
@@ -291,7 +292,8 @@ read_and_process_and_calc <- function(args_list) {
     data = company_annual_profits,
     shock_year = transition_scenario$year_of_shock,
     end_of_analysis = end_year_lookup,
-    risk_free_interest_rate = risk_free_rate
+    risk_free_interest_rate = risk_free_rate,
+    exposure_at_default = exposure_by_technology_and_company
   )
 
   # TODO: ADO 879 - note which companies produce missing results due to

--- a/R/wrangle_and_check.R
+++ b/R/wrangle_and_check.R
@@ -511,10 +511,8 @@ wrangle_results <- function(results_list, sensitivity_analysis_vars) {
     portfolio_value_changes = portfolio_value_changes,
     company_expected_loss = company_expected_loss,
     company_pd_changes_annual = company_pd_changes_annual,
-    # sector_pd_changes_annual = sector_pd_changes_annual,
     portfolio_pd_changes_annual = portfolio_pd_changes_annual,
     company_pd_changes_overall = company_pd_changes_overall,
-    # sector_pd_changes_overall = sector_pd_changes_overall,
     portfolio_pd_changes_overall = portfolio_pd_changes_overall,
     company_trajectories = company_trajectories
   ))

--- a/R/write_results.R
+++ b/R/write_results.R
@@ -34,10 +34,10 @@ write_stress_test_results <- function(results_list, asset_type, iter_var,
       glue::glue("{asset_type}_company_pd_changes_annual_{iter_var}.csv")
     ))
 
-  results_list$sector_pd_changes_annual %>%
+  results_list$portfolio_pd_changes_annual %>%
     readr::write_csv(file.path(
       output_path,
-      glue::glue("{asset_type}_sector_pd_changes_annual_{iter_var}.csv")
+      glue::glue("{asset_type}_portfolio_pd_changes_annual_{iter_var}.csv")
     ))
 
   results_list$company_pd_changes_overall %>%
@@ -46,10 +46,10 @@ write_stress_test_results <- function(results_list, asset_type, iter_var,
       glue::glue("{asset_type}_company_pd_changes_overall_{iter_var}.csv")
     ))
 
-  results_list$sector_pd_changes_overall %>%
+  results_list$portfolio_pd_changes_overall %>%
     readr::write_csv(file.path(
       output_path,
-      glue::glue("{asset_type}_sector_pd_changes_overall_{iter_var}.csv")
+      glue::glue("{asset_type}_portfolio_pd_changes_overall_{iter_var}.csv")
     ))
 
   results_list$company_trajectories %>%

--- a/man/calculate_pd_change_annual.Rd
+++ b/man/calculate_pd_change_annual.Rd
@@ -16,14 +16,19 @@ only after the shock, we get diverging starting points.}
 \usage{
 calculate_pd_change_annual(
   data,
+  exposure_at_default,
   shock_year = NULL,
   end_of_analysis = NULL,
-  risk_free_interest_rate = NULL,
-  exposure_at_default = NULL
+  risk_free_interest_rate = NULL
 )
 }
 \arguments{
 \item{data}{A dataframe containing the (discounted) annual profits}
+
+\item{exposure_at_default}{A dataframe that contains the share of the
+portfolio value of each company-technology combination. Used to quantify
+the impact of the company-tech level shock on higher levels of aggregation
+in the portfolio}
 
 \item{shock_year}{A numeric vector of length one that indicates in which year
 the policy shock strikes in a given scenario}
@@ -33,11 +38,6 @@ which year the analysis runs}
 
 \item{risk_free_interest_rate}{A numeric vector of length one that indicates
 the risk free rate of interest}
-
-\item{exposure_at_default}{A dataframe that contains the share of the
-portfolio value of each company-technology combination. Used to quantify
-the impact of the company-tech level shock on higher levels of aggregation
-in the portfolio}
 }
 \description{
 Calculate change in probabilities of default (PDs) of loans connected to

--- a/man/calculate_pd_change_annual.Rd
+++ b/man/calculate_pd_change_annual.Rd
@@ -18,7 +18,8 @@ calculate_pd_change_annual(
   data,
   shock_year = NULL,
   end_of_analysis = NULL,
-  risk_free_interest_rate = NULL
+  risk_free_interest_rate = NULL,
+  exposure_at_default = NULL
 )
 }
 \arguments{
@@ -32,6 +33,11 @@ which year the analysis runs}
 
 \item{risk_free_interest_rate}{A numeric vector of length one that indicates
 the risk free rate of interest}
+
+\item{exposure_at_default}{A dataframe that contains the share of the
+portfolio value of each company-technology combination. Used to quantify
+the impact of the company-tech level shock on higher levels of aggregation
+in the portfolio}
 }
 \description{
 Calculate change in probabilities of default (PDs) of loans connected to

--- a/man/calculate_pd_change_overall.Rd
+++ b/man/calculate_pd_change_overall.Rd
@@ -12,14 +12,19 @@ level.}
 \usage{
 calculate_pd_change_overall(
   data,
+  exposure_at_default,
   shock_year = NULL,
   end_of_analysis = NULL,
-  risk_free_interest_rate = NULL,
-  exposure_at_default = NULL
+  risk_free_interest_rate = NULL
 )
 }
 \arguments{
 \item{data}{A dataframe containing the (discounted) annual profits}
+
+\item{exposure_at_default}{A dataframe that contains the share of the
+portfolio value of each company-technology combination. Used to quantify
+the impact of the company-tech level shock on higher levels of aggregation
+in the portfolio}
 
 \item{shock_year}{A numeric vector of length one that indicates in which year
 the policy shock strikes in a given scenario}
@@ -29,11 +34,6 @@ which year the analysis runs}
 
 \item{risk_free_interest_rate}{A numeric vector of length one that indicates
 the risk free rate of interest}
-
-\item{exposure_at_default}{A dataframe that contains the share of the
-portfolio value of each company-technology combination. Used to quantify
-the impact of the company-tech level shock on higher levels of aggregation
-in the portfolio}
 }
 \description{
 Calculate change in probabilities of default (PDs) of loans connected to

--- a/man/calculate_pd_change_overall.Rd
+++ b/man/calculate_pd_change_overall.Rd
@@ -14,7 +14,8 @@ calculate_pd_change_overall(
   data,
   shock_year = NULL,
   end_of_analysis = NULL,
-  risk_free_interest_rate = NULL
+  risk_free_interest_rate = NULL,
+  exposure_at_default = NULL
 )
 }
 \arguments{
@@ -28,6 +29,11 @@ which year the analysis runs}
 
 \item{risk_free_interest_rate}{A numeric vector of length one that indicates
 the risk free rate of interest}
+
+\item{exposure_at_default}{A dataframe that contains the share of the
+portfolio value of each company-technology combination. Used to quantify
+the impact of the company-tech level shock on higher levels of aggregation
+in the portfolio}
 }
 \description{
 Calculate change in probabilities of default (PDs) of loans connected to

--- a/tests/testthat/test-calculate_annual_pd_changes.R
+++ b/tests/testthat/test-calculate_annual_pd_changes.R
@@ -24,6 +24,12 @@ test_that("with missing argument for shock_year, calculate_pd_change_annual
 
 test_that("PD_changes point in expected direction", {
   test_data <- read_test_data("loanbook_annual_profits.csv")
+  test_exposure <- tibble::tribble(
+    ~investor_name, ~portfolio_name, ~company_name, ~year, ~scenario_geography, ~ald_sector, ~technology, ~plan_carsten, ~plan_sec_carsten, ~term, ~pd,
+    "Meta Investor", "Meta Investor", "company_1", 2025, "Global", "Power", "NuclearCap", 0.01, 0.01, 1, 0.01,
+    "Meta Investor", "Meta Investor", "company_2", 2025, "Global", "Oil&gas", "Oil", 0.01, 0.01, 1, 0.01,
+    "Meta Investor", "Meta Investor", "Power Company", 2025, "Global", "Power", "NuclearCap", 0.01, 0.01, 1, 0.01,
+  )
 
   test_shock_year <- 2030
   test_end_of_analysis <- 2040
@@ -55,7 +61,8 @@ test_that("PD_changes point in expected direction", {
     data = test_data,
     shock_year = test_shock_year,
     end_of_analysis = test_end_of_analysis,
-    risk_free_interest_rate = test_risk_free_rate
+    risk_free_interest_rate = test_risk_free_rate,
+    exposure_at_default = test_exposure
   )
 
   results_direction <- test_results %>%

--- a/tests/testthat/test-calculate_annual_pd_changes.R
+++ b/tests/testthat/test-calculate_annual_pd_changes.R
@@ -8,6 +8,12 @@ test_that("without specified arguments, function throws error", {
 test_that("with missing argument for shock_year, calculate_pd_change_annual
           throws error", {
   test_data <- read_test_data("loanbook_annual_profits.csv")
+  test_exposure <- tibble::tribble(
+    ~investor_name, ~portfolio_name, ~company_name, ~year, ~scenario_geography, ~ald_sector, ~technology, ~plan_carsten, ~plan_sec_carsten, ~term, ~pd,
+    "Meta Investor", "Meta Investor", "company_1", 2025, "Global", "Power", "NuclearCap", 0.01, 0.01, 1, 0.01,
+    "Meta Investor", "Meta Investor", "company_2", 2025, "Global", "Oil&gas", "Oil", 0.01, 0.01, 1, 0.01,
+    "Meta Investor", "Meta Investor", "Power Company", 2025, "Global", "Power", "NuclearCap", 0.01, 0.01, 1, 0.01,
+  )
 
   test_end_of_analysis <- 2040
   test_risk_free_rate <- 0.05
@@ -15,6 +21,7 @@ test_that("with missing argument for shock_year, calculate_pd_change_annual
   testthat::expect_error(
     calculate_pd_change_annual(
       data = test_data,
+      exposure_at_default = test_exposure,
       end_of_analysis = test_end_of_analysis,
       risk_free_interest_rate = test_risk_free_rate
     ),
@@ -59,10 +66,10 @@ test_that("PD_changes point in expected direction", {
 
   test_results <- calculate_pd_change_annual(
     data = test_data,
+    exposure_at_default = test_exposure,
     shock_year = test_shock_year,
     end_of_analysis = test_end_of_analysis,
-    risk_free_interest_rate = test_risk_free_rate,
-    exposure_at_default = test_exposure
+    risk_free_interest_rate = test_risk_free_rate
   )
 
   results_direction <- test_results %>%

--- a/tests/testthat/test-calculate_overall_pd_changes.R
+++ b/tests/testthat/test-calculate_overall_pd_changes.R
@@ -9,6 +9,12 @@ test_that("without specified arguments, calculate_pd_change_overall throws
 test_that("with missing argument for shock_year, calculate_pd_change_overall
           throws error", {
   test_data <- read_test_data("loanbook_annual_profits.csv")
+  test_exposure <- tibble::tribble(
+    ~investor_name, ~portfolio_name, ~company_name, ~year, ~scenario_geography, ~ald_sector, ~technology, ~plan_carsten, ~plan_sec_carsten, ~term, ~pd,
+    "Meta Investor", "Meta Investor", "company_1", 2025, "Global", "Power", "NuclearCap", 0.01, 0.01, 1, 0.01,
+    "Meta Investor", "Meta Investor", "company_2", 2025, "Global", "Oil&gas", "Oil", 0.01, 0.01, 1, 0.01,
+    "Meta Investor", "Meta Investor", "Power Company", 2025, "Global", "Power", "NuclearCap", 0.01, 0.01, 1, 0.01,
+  )
 
   test_end_of_analysis <- 2040
   test_risk_free_rate <- 0.05
@@ -16,6 +22,7 @@ test_that("with missing argument for shock_year, calculate_pd_change_overall
   testthat::expect_error(
     calculate_pd_change_overall(
       data = test_data,
+      exposure_at_default = test_exposure,
       end_of_analysis = test_end_of_analysis,
       risk_free_interest_rate = test_risk_free_rate
     ),
@@ -60,10 +67,10 @@ test_that("PD_changes point in expected direction", {
 
   test_results <- calculate_pd_change_overall(
     data = test_data,
+    exposure_at_default = test_exposure,
     shock_year = test_shock_year,
     end_of_analysis = test_end_of_analysis,
-    risk_free_interest_rate = test_risk_free_rate,
-    exposure_at_default = test_exposure
+    risk_free_interest_rate = test_risk_free_rate
   )
 
   results_direction <- test_results %>%

--- a/tests/testthat/test-calculate_overall_pd_changes.R
+++ b/tests/testthat/test-calculate_overall_pd_changes.R
@@ -25,6 +25,12 @@ test_that("with missing argument for shock_year, calculate_pd_change_overall
 
 test_that("PD_changes point in expected direction", {
   test_data <- read_test_data("loanbook_annual_profits.csv")
+  test_exposure <- tibble::tribble(
+    ~investor_name, ~portfolio_name, ~company_name, ~year, ~scenario_geography, ~ald_sector, ~technology, ~plan_carsten, ~plan_sec_carsten, ~term, ~pd,
+    "Meta Investor", "Meta Investor", "company_1", 2025, "Global", "Power", "NuclearCap", 0.01, 0.01, 1, 0.01,
+    "Meta Investor", "Meta Investor", "company_2", 2025, "Global", "Oil&gas", "Oil", 0.01, 0.01, 1, 0.01,
+    "Meta Investor", "Meta Investor", "Power Company", 2025, "Global", "Power", "NuclearCap", 0.01, 0.01, 1, 0.01,
+  )
 
   test_shock_year <- 2030
   test_end_of_analysis <- 2040
@@ -56,7 +62,8 @@ test_that("PD_changes point in expected direction", {
     data = test_data,
     shock_year = test_shock_year,
     end_of_analysis = test_end_of_analysis,
-    risk_free_interest_rate = test_risk_free_rate
+    risk_free_interest_rate = test_risk_free_rate,
+    exposure_at_default = test_exposure
   )
 
   results_direction <- test_results %>%


### PR DESCRIPTION
closes ADO 4309: https://dev.azure.com/2DegreesInvesting/2DegreesInvesting/_workitems/edit/4309

This PR:
- calculates aggregate sector PD changes by weighting the companies in the loan book/portfolio by exposure
- adjusts the naming of the output files to match the logic of the market risk module