### PR TITLE
filter out companies form pacta without valid exposures

### DIFF
--- a/R/process_data.R
+++ b/R/process_data.R
@@ -69,7 +69,9 @@ process_pacta_results <- function(data, start_year, end_year, time_horizon,
 }
 
 #' Remove rows from PACTA results that belong to company-technology combinations
-#' for which there is no information on the exposure in the portfolio
+#' for which there is no information on the exposure in the portfolio. We join
+#' company results on the portfolio exposure based on the last available year of
+#' the production forecast. Hence we filter for missings in that year.
 #'
 #' @inheritParams calculate_annual_profits
 #' @inheritParams report_company_drops

--- a/R/process_data.R
+++ b/R/process_data.R
@@ -85,9 +85,12 @@ remove_companies_with_missing_exposures <- function(data,
                                                     log_path) {
   n_companies_pre <- length(unique(data$company_name))
 
+  # we merge the exposure of the last year of the forecast on the company
+  # results for the aggregation, to get the closest picture to the shock year.
+  # Hence start_year + time_horizon
   companies_missing_exposure_value <- data %>%
     dplyr::filter(.data$year == .env$start_year + .env$time_horizon) %>%
-    dplyr::filter(is.na(.data$plan_carsten)) #%>%
+    dplyr::filter(is.na(.data$plan_carsten))
 
   data_filtered <- data %>%
     dplyr::anti_join(

--- a/R/run_stress_test.R
+++ b/R/run_stress_test.R
@@ -201,7 +201,8 @@ read_and_process_and_calc <- function(args_list) {
       fallback_term = fallback_term,
       scenario_geography = scenario_geography,
       baseline_scenario = baseline_scenario,
-      shock_scenario = shock_scenario
+      shock_scenario = shock_scenario,
+      log_path = log_path
     )
 
   input_data_list <- list(

--- a/man/process_pacta_results.Rd
+++ b/man/process_pacta_results.Rd
@@ -15,7 +15,8 @@ process_pacta_results(
   sectors,
   technologies,
   allocation_method,
-  asset_type
+  asset_type,
+  log_path
 )
 }
 \arguments{
@@ -45,6 +46,8 @@ allocation rule.}
 
 \item{asset_type}{String holding asset_type. For accepted values compare
 \code{stress_test_arguments}.}
+
+\item{log_path}{String holding path to log file.}
 }
 \value{
 A tibble of data as indicated by function name.


### PR DESCRIPTION
removes rows from pacta results that do not have plan_carsten (company technology exposure) in the final year of the production forecast. These will not be usable when aggregating the results to the portfolio level later on