### PR TITLE
Ado 4121

### DIFF
--- a/R/format_loanbook_st.R
+++ b/R/format_loanbook_st.R
@@ -107,7 +107,7 @@ format_loanbook_st <- function(data,
 
   # custom formatting to adapt to P4I style scenanrio data
   results_loanbook <- results_loanbook %>%
-    dplyr::mutate(scenario_geography = gsub(" ", "", region, fixed = TRUE)) %>%
+    dplyr::mutate(scenario_geography = gsub(" ", "", scenario_geography, fixed = TRUE)) %>%
     dplyr::mutate(scenario_geography = case_when(
       scenario_geography == "CentralAndSouthAmerica" ~ "CentralandSouthAmerica",
       scenario_geography == "EuropeanUnion" ~ "EU",

--- a/R/format_loanbook_st.R
+++ b/R/format_loanbook_st.R
@@ -108,7 +108,7 @@ format_loanbook_st <- function(data,
   # custom formatting to adapt to P4I style scenanrio data
   results_loanbook <- results_loanbook %>%
     dplyr::mutate(scenario_geography = gsub(" ", "", scenario_geography, fixed = TRUE)) %>%
-    dplyr::mutate(scenario_geography = case_when(
+    dplyr::mutate(scenario_geography = dplyr::case_when(
       scenario_geography == "CentralAndSouthAmerica" ~ "CentralandSouthAmerica",
       scenario_geography == "EuropeanUnion" ~ "EU",
       scenario_geography == "NonOecd" ~ "NonOECD",

--- a/R/format_loanbook_st.R
+++ b/R/format_loanbook_st.R
@@ -109,12 +109,12 @@ format_loanbook_st <- function(data,
   results_loanbook <- results_loanbook %>%
     dplyr::mutate(scenario_geography = gsub(" ", "", scenario_geography, fixed = TRUE)) %>%
     dplyr::mutate(scenario_geography = dplyr::case_when(
-      scenario_geography == "CentralAndSouthAmerica" ~ "CentralandSouthAmerica",
-      scenario_geography == "EuropeanUnion" ~ "EU",
-      scenario_geography == "NonOecd" ~ "NonOECD",
-      scenario_geography == "Oecd" ~ "OECD",
-      scenario_geography == "UnitedStates" ~ "US",
-      TRUE ~ scenario_geography
+      .data$scenario_geography == "CentralAndSouthAmerica" ~ "CentralandSouthAmerica",
+      .data$scenario_geography == "EuropeanUnion" ~ "EU",
+      .data$scenario_geography == "NonOecd" ~ "NonOECD",
+      .data$scenario_geography == "Oecd" ~ "OECD",
+      .data$scenario_geography == "UnitedStates" ~ "US",
+      TRUE ~ .data$scenario_geography
     ))
 
   plan <- results_loanbook %>%

--- a/R/format_loanbook_st.R
+++ b/R/format_loanbook_st.R
@@ -105,6 +105,18 @@ format_loanbook_st <- function(data,
       .data$plan_sec_prod, .data$plan_sec_carsten
     )
 
+  # custom formatting to adapt to P4I style scenanrio data
+  results_loanbook <- results_loanbook %>%
+    dplyr::mutate(scenario_geography = gsub(" ", "", region, fixed = TRUE)) %>%
+    dplyr::mutate(scenario_geography = case_when(
+      scenario_geography == "CentralAndSouthAmerica" ~ "CentralandSouthAmerica",
+      scenario_geography == "EuropeanUnion" ~ "EU",
+      scenario_geography == "NonOecd" ~ "NonOECD",
+      scenario_geography == "Oecd" ~ "OECD",
+      scenario_geography == "UnitedStates" ~ "US",
+      TRUE ~ scenario_geography
+    ))
+
   plan <- results_loanbook %>%
     # scenario == "projected" corresponds to company production plans in P4B
     dplyr::filter(.data$scenario == "projected") %>%

--- a/R/run_prep_calculation_loans.R
+++ b/R/run_prep_calculation_loans.R
@@ -302,7 +302,6 @@ run_prep_calculation_loans <- function(input_path_project_specific,
   p4b_tms_results_loan_share <- p4b_tms_results %>%
     # TODO why left_join?
     dplyr::left_join(loan_share, by = c("sector" = "sector_ald", "name_ald")) %>%
-    dplyr::filter(.data$region == "global") %>%
     dplyr::select(
       -c(
         .data$comp_loan_size_outstanding, .data$comp_loan_size_credit_limit,


### PR DESCRIPTION
changed loanbook prep to return all geos and to use custom formatting of SenarioAnalysisInput data. 
These changes do not affect the results as calculated for level global. 
Please not however that not all geos as identified here: https://github.com/2DegreesInvesting/r2dii.stress.test.data/blob/898f30a0b80d837ba59c88665c998b503eaf2d67/data_overview/scenario_x_scenario_geography_availability.R#L422 are included. Included are ```[1] "Global"                 "AdvancedEconomies"      "Africa"                 "AsiaPacific"            "CentralandSouthAmerica" "DevelopingEconomies"   
 [7] "Eurasia"                "Europe"                 "EU"                     "MiddleEast"             "NonOECD"                "NorthAmerica"          
[13] "OECD"                   "China"                  "SoutheastAsia"  ```