### PR TITLE
lbk prep aggregate plan_sec_carsten to sector not tech

### DIFF
--- a/R/format_loanbook_st.R
+++ b/R/format_loanbook_st.R
@@ -92,7 +92,7 @@ format_loanbook_st <- function(data,
         .data$production_unweighted, .data$technology_share
       )
     ) %>%
-    dplyr::group_by(!!!rlang::syms(group_vars)) %>%
+    dplyr::group_by(!!!rlang::syms(group_vars[group_vars != "technology"])) %>%
     dplyr::mutate(
       scenario_geography = stringr::str_to_title(.data$scenario_geography),
       plan_sec_prod = sum(.data$plan_tech_prod, na.rm = TRUE),


### PR DESCRIPTION
sector level values in loan book preparation were previously erroneously aggregated to technology level
this led to wrong plan_sec_carsten values.
fixed the aggregation