### PR TITLE
no env

### DIFF
--- a/R/process_data.R
+++ b/R/process_data.R
@@ -221,8 +221,8 @@ process_price_data <- function(data, technologies, sectors, start_year, end_year
       expected_levels_list =
         list(
           year = start_year:end_year,
-          ald_sector = .env$sectors,
-          technology = .env$technologies,
+          ald_sector = sectors,
+          technology = technologies,
           scenario = scenarios_filter
         )
     ) %>%


### PR DESCRIPTION
Incorrectly used masking outside masking context. Apparently rlang < 1.0.0 did not throw an error in this case, so it was so far not detected.