### PR TITLE
add linebreak

### DIFF
--- a/R/filter.R
+++ b/R/filter.R
@@ -32,7 +32,7 @@ keep_merton_compatible_rows <- function(data, stage) {
     dplyr::select(-.data$V0_base, -.data$V0_late_sudden)
 
   if (nrow(data_filtered) < nrow(data)) {
-    cat(paste0("Removed ", nrow(data) - nrow(data_filtered), " rows when checking for compatibility with merton model."))
+    cat(paste0("Removed ", nrow(data) - nrow(data_filtered), " rows when checking for compatibility with merton model. \n"))
 
     if (nrow(data_filtered) == 0) {
       stop("No data remain after removing rows that are not compatible with merton model.")


### PR DESCRIPTION
Purely aesthetic change to add a missing linebreak. You can see its effect when calculating the test equity results.