### PR TITLE
aggregate results accounting for sensitivity var

### DIFF
--- a/R/run_stress_test.R
+++ b/R/run_stress_test.R
@@ -107,7 +107,8 @@ run_stress_test <- function(asset_type,
 
   st_results_aggregated <- aggregate_results(
     results_list = st_results,
-    sensitivity_analysis_vars = names(args_list)[!names(args_list) %in% setup_vars_lookup]
+    sensitivity_analysis_vars = names(args_list)[!names(args_list) %in% setup_vars_lookup],
+    iter_var = iter_var
   )
 
   st_results_wrangled_and_checked <- wrangle_results(

--- a/man/aggregate_results.Rd
+++ b/man/aggregate_results.Rd
@@ -4,13 +4,16 @@
 \alias{aggregate_results}
 \title{Aggregate results}
 \usage{
-aggregate_results(results_list, sensitivity_analysis_vars)
+aggregate_results(results_list, sensitivity_analysis_vars, iter_var)
 }
 \arguments{
 \item{results_list}{A list of results.}
 
 \item{sensitivity_analysis_vars}{String vector holding names of iteration
 arguments.}
+
+\item{iter_var}{String vector holding the variable over which to iterate in
+sensitivity analysis}
 }
 \value{
 A list including basic and aggregated results.


### PR DESCRIPTION
closes ADO4710: https://dev.azure.com/2DegreesInvesting/2DegreesInvesting/_workitems/edit/4710

This PR:
- adds the iteration variable on which a sensitivity analysis is run to the grouping vars in result aggregation
- handles the standard (non sensitivity) case

Expectation:
- Previously, ignoring the iteration variable in aggregating results lead to a situation, where only the lowest level results would differ between iteration runs, as these are non aggregated
- Any level of aggregation would lead to inflated sums or distorted means, because the aggregation to a higher level would e.g. not consider the need to keep the results of two different shock years apart from each other
- Test run shows this problem is now fixed