### PR TITLE
remove comp sector combination when no production given

### DIFF
--- a/R/process_data.R
+++ b/R/process_data.R
@@ -205,9 +205,6 @@ remove_sectors_with_missing_production <- function(data,
                                                    log_path) {
   n_companies_pre <- length(unique(data$company_name))
 
-  # we merge the exposure of the last year of the forecast on the company
-  # results for the aggregation, to get the closest picture to the shock year.
-  # Hence start_year + time_horizon
   companies_missing_sector_production <- data %>%
     dplyr::filter(.data$year == .env$start_year + .env$time_horizon) %>%
     dplyr::group_by(

--- a/R/process_data.R
+++ b/R/process_data.R
@@ -45,6 +45,11 @@ process_pacta_results <- function(data, start_year, end_year, time_horizon,
       time_horizon = time_horizon,
       log_path = log_path
     ) %>%
+    remove_sectors_with_missing_production(
+      start_year = start_year,
+      time_horizon = time_horizon,
+      log_path = log_path
+    ) %>%
     stop_if_empty(data_name = "Pacta Results") %>%
     check_level_availability(
       data_name = "Pacta Results",
@@ -179,6 +184,73 @@ set_initial_plan_carsten_missings_to_zero <- function(data,
     )
 
   return(data)
+}
+
+#' Remove rows from PACTA results that belong to company-sector combinations
+#' for which there is no positive production value in the relevant year of
+#' exposure (last year of forecast). This handles the edge case that a company
+#' may have a positive exposure for this sector, but none of the technologies
+#' covered in this analysis have any positive production. Such inconsistencies
+#' may arise e.g. because of unclear separation of the LDV and HDV sectors.
+#'
+#' @inheritParams calculate_annual_profits
+#' @inheritParams report_company_drops
+#' @param data tibble containing filtered PACTA results
+#'
+#' @return A tibble of data without rows with no exposure info
+#' @noRd
+remove_sectors_with_missing_production <- function(data,
+                                                   start_year,
+                                                   time_horizon,
+                                                   log_path) {
+  n_companies_pre <- length(unique(data$company_name))
+
+  # we merge the exposure of the last year of the forecast on the company
+  # results for the aggregation, to get the closest picture to the shock year.
+  # Hence start_year + time_horizon
+  companies_missing_sector_production <- data %>%
+    dplyr::filter(.data$year == .env$start_year + .env$time_horizon) %>%
+    dplyr::group_by(
+      .data$investor_name, .data$portfolio_name, .data$company_name,
+      .data$scenario, .data$scenario_geography, .data$ald_sector
+    ) %>%
+    dplyr::summarise(
+      sector_prod = sum(.data$plan_tech_prod, na.rm = TRUE),
+      .groups = "drop"
+    ) %>%
+    dplyr::ungroup() %>%
+    dplyr::filter(.data$sector_prod <= 0)
+
+  data_filtered <- data %>%
+    dplyr::anti_join(
+      companies_missing_sector_production,
+      by = c("company_name", "ald_sector")
+    )
+
+  n_companies_post <- length(unique(data_filtered$company_name))
+
+  if (n_companies_pre > n_companies_post) {
+    percent_loss <- (n_companies_pre - n_companies_post) * 100 / n_companies_pre
+    affected_companies <- sort(
+      setdiff(
+        data$company_name,
+        data_filtered$company_name
+      )
+    )
+    paste_write(
+      format_indent_1(), "When filtering out holdings with 0 production in relevant sector, dropped rows for",
+      n_companies_pre - n_companies_post, "out of", n_companies_pre, "companies",
+      log_path = log_path
+    )
+    paste_write(format_indent_2(), "percent loss:", percent_loss, log_path = log_path)
+    paste_write(format_indent_2(), "affected companies:", log_path = log_path)
+    purrr::walk(affected_companies, function(company) {
+      paste_write(format_indent_2(), company, log_path = log_path)
+    })
+  }
+
+
+  return(data_filtered)
 }
 
 #' Process data of type indicated by function name

--- a/R/process_data.R
+++ b/R/process_data.R
@@ -208,8 +208,7 @@ remove_sectors_with_missing_production <- function(data,
   companies_missing_sector_production <- data %>%
     dplyr::filter(.data$year == .env$start_year + .env$time_horizon) %>%
     dplyr::group_by(
-      .data$investor_name, .data$portfolio_name, .data$company_name,
-      .data$scenario, .data$scenario_geography, .data$ald_sector
+      .data$company_name, .data$scenario, .data$ald_sector
     ) %>%
     dplyr::summarise(
       sector_prod = sum(.data$plan_tech_prod, na.rm = TRUE),
@@ -221,7 +220,7 @@ remove_sectors_with_missing_production <- function(data,
   data_filtered <- data %>%
     dplyr::anti_join(
       companies_missing_sector_production,
-      by = c("company_name", "ald_sector")
+      by = c("company_name", "scenario", "ald_sector")
     )
 
   n_companies_post <- length(unique(data_filtered$company_name))

--- a/R/process_data.R
+++ b/R/process_data.R
@@ -217,6 +217,10 @@ remove_sectors_with_missing_production <- function(data,
     dplyr::ungroup() %>%
     dplyr::filter(.data$sector_prod <= 0)
 
+  # while this technically removes problematic cases for only certain scenarios
+  # for a company, this will in practice not lead to one scenario being removed
+  # and another remaining in the data because the production plans are the same
+  # across scenarios.
   data_filtered <- data %>%
     dplyr::anti_join(
       companies_missing_sector_production,

--- a/tests/testthat/test-process_data.R
+++ b/tests/testthat/test-process_data.R
@@ -1,0 +1,50 @@
+test_that("company with positive exposure and production value is not removed", {
+  test_data <- tibble::tribble(
+    ~year, ~investor_name, ~portfolio_name, ~ald_sector, ~technology, ~scenario, ~scenario_geography, ~company_name, ~plan_tech_prod, ~plan_carsten,
+    2020, "investor", "portfolio", "Automotive", "Electric", "scenario_a", "Global", "company_x", 1, 0.01,
+    2021, "investor", "portfolio", "Automotive", "Electric", "scenario_a", "Global", "company_x", 1, 0.01,
+    2022, "investor", "portfolio", "Automotive", "Electric", "scenario_a", "Global", "company_x", 1, 0.01,
+    2023, "investor", "portfolio", "Automotive", "Electric", "scenario_a", "Global", "company_x", 1, 0.01,
+    2024, "investor", "portfolio", "Automotive", "Electric", "scenario_a", "Global", "company_x", 1, 0.01,
+    2025, "investor", "portfolio", "Automotive", "Electric", "scenario_a", "Global", "company_x", 1, 0.01,
+  )
+  test_start_year <- 2020
+  test_time_horizon <- 5
+  test_log_path <- file.path(tempdir(), "log.txt")
+
+  not_removed <- test_data %>%
+    remove_sectors_with_missing_production(
+      start_year = test_start_year,
+      time_horizon = test_time_horizon,
+      log_path = test_log_path
+    )
+  testthat::expect_equal(nrow(not_removed), nrow(test_data))
+
+  unlink(test_log_path)
+})
+
+test_that("company with positive exposure and zero production value is removed", {
+  test_data <- tibble::tribble(
+    ~year, ~investor_name, ~portfolio_name, ~ald_sector, ~technology, ~scenario, ~scenario_geography, ~company_name, ~plan_tech_prod, ~plan_carsten,
+    2020, "investor", "portfolio", "Automotive", "Electric", "scenario_a", "Global", "company_x", 0, 0.01,
+    2021, "investor", "portfolio", "Automotive", "Electric", "scenario_a", "Global", "company_x", 0, 0.01,
+    2022, "investor", "portfolio", "Automotive", "Electric", "scenario_a", "Global", "company_x", 0, 0.01,
+    2023, "investor", "portfolio", "Automotive", "Electric", "scenario_a", "Global", "company_x", 0, 0.01,
+    2024, "investor", "portfolio", "Automotive", "Electric", "scenario_a", "Global", "company_x", 0, 0.01,
+    2025, "investor", "portfolio", "Automotive", "Electric", "scenario_a", "Global", "company_x", 0, 0.01,
+  )
+
+  test_start_year <- 2020
+  test_time_horizon <- 5
+  test_log_path <- file.path(tempdir(), "log.txt")
+
+  removed <- test_data %>%
+    remove_sectors_with_missing_production(
+      start_year = test_start_year,
+      time_horizon = test_time_horizon,
+      log_path = test_log_path
+    )
+  testthat::expect_equal(nrow(removed), 0)
+
+  unlink(test_log_path)
+})

--- a/tests/testthat/test-process_data.R
+++ b/tests/testthat/test-process_data.R
@@ -25,13 +25,13 @@ test_that("company with positive exposure and production value is not removed", 
 
 test_that("company with positive exposure and zero production value is removed", {
   test_data <- tibble::tribble(
-    ~year, ~investor_name, ~portfolio_name, ~ald_sector, ~technology, ~scenario, ~scenario_geography, ~company_name, ~plan_tech_prod, ~plan_carsten,
-    2020, "investor", "portfolio", "Automotive", "Electric", "scenario_a", "Global", "company_x", 0, 0.01,
-    2021, "investor", "portfolio", "Automotive", "Electric", "scenario_a", "Global", "company_x", 0, 0.01,
-    2022, "investor", "portfolio", "Automotive", "Electric", "scenario_a", "Global", "company_x", 0, 0.01,
-    2023, "investor", "portfolio", "Automotive", "Electric", "scenario_a", "Global", "company_x", 0, 0.01,
-    2024, "investor", "portfolio", "Automotive", "Electric", "scenario_a", "Global", "company_x", 0, 0.01,
-    2025, "investor", "portfolio", "Automotive", "Electric", "scenario_a", "Global", "company_x", 0, 0.01,
+    ~year, ~ald_sector, ~technology, ~scenario, ~company_name, ~plan_tech_prod, ~plan_carsten,
+    2020, "Automotive", "Electric", "scenario_a", "company_x", 0, 0.01,
+    2021, "Automotive", "Electric", "scenario_a", "company_x", 0, 0.01,
+    2022, "Automotive", "Electric", "scenario_a", "company_x", 0, 0.01,
+    2023, "Automotive", "Electric", "scenario_a", "company_x", 0, 0.01,
+    2024, "Automotive", "Electric", "scenario_a", "company_x", 0, 0.01,
+    2025, "Automotive", "Electric", "scenario_a", "company_x", 0, 0.01,
   )
 
   test_start_year <- 2020


### PR DESCRIPTION
closes ADO 4713 https://dev.azure.com/2DegreesInvesting/2DegreesInvesting/_workitems/edit/4713

This PR:
- removes company-sector combinations in case they have 0 positive production in the relevant year of exposure (last year of the prod forecast)
- this catches the edge case that a company may produce HDVs but no LDVs and since both are part of the sector Automotive, that company will have a positive exposure but no production
- adds logging for which companies are removed due to this

Expectation:
- no such companies present in the trajectory results anymore
- no change to aggregate results since this case was previously caught there by chance

