### PR TITLE
handle furhter edge cases to rm missings from comp profit trajectories

### DIFF
--- a/R/lookup.R
+++ b/R/lookup.R
@@ -93,6 +93,8 @@ p4b_scenarios_lookup <- c(
 # holds names of input arguments to run_stress_test that are not model parameters
 setup_vars_lookup <- c("input_path_project_agnostic", "input_path_project_specific", "output_path", "iter_var", "return_results")
 
+high_carbon_tech_lookup <- c("ICE", "Coal", "Oil", "Gas", "CoalCap", "GasCap", "OilCap")
+
 countries_for_regions_mapper_lookup <- tibble::tibble(
   region = c("brazil", "brazil", "india", "india", "japan", "japan", "russia", "russia", "south africa", "south africa", "united states", "united states"),
   isos = c("br", "br", "in", "in", "jp", "jp", "ru", "ru", "za", "za", "us", "us"),

--- a/R/process_data.R
+++ b/R/process_data.R
@@ -350,7 +350,7 @@ remove_high_carbon_tech_with_missing_production <- function(data,
   companies_missing_high_carbon_tech_production <- data %>%
     dplyr::filter(.data$technology %in% c("ICE", "Coal", "Oil", "Gas", "CoalCap", "GasCap", "OilCap")) %>%
     dplyr::group_by(
-      .data$company_name, .data$scenario, .data$technology
+      .data$company_name, .data$scenario, .data$ald_sector, .data$technology
     ) %>%
     dplyr::summarise(
       technology_prod = sum(.data$plan_tech_prod, na.rm = TRUE),
@@ -366,7 +366,7 @@ remove_high_carbon_tech_with_missing_production <- function(data,
   data_filtered <- data %>%
     dplyr::anti_join(
       companies_missing_high_carbon_tech_production,
-      by = c("company_name", "scenario", "technology")
+      by = c("company_name", "scenario", "ald_sector", "technology")
     )
 
   n_companies_post <- length(unique(data_filtered$company_name))

--- a/R/process_data.R
+++ b/R/process_data.R
@@ -45,7 +45,16 @@ process_pacta_results <- function(data, start_year, end_year, time_horizon,
       time_horizon = time_horizon,
       log_path = log_path
     ) %>%
-    remove_sectors_with_missing_production(
+    remove_sectors_with_missing_production_end_of_forecast(
+      start_year = start_year,
+      time_horizon = time_horizon,
+      log_path = log_path
+    ) %>%
+    remove_sectors_with_missing_production_start_year(
+      start_year = start_year,
+      log_path = log_path
+    ) %>%
+    remove_high_carbon_tech_with_missing_production(
       start_year = start_year,
       time_horizon = time_horizon,
       log_path = log_path
@@ -199,7 +208,7 @@ set_initial_plan_carsten_missings_to_zero <- function(data,
 #'
 #' @return A tibble of data without rows with no exposure info
 #' @noRd
-remove_sectors_with_missing_production <- function(data,
+remove_sectors_with_missing_production_end_of_forecast <- function(data,
                                                    start_year,
                                                    time_horizon,
                                                    log_path) {
@@ -239,6 +248,139 @@ remove_sectors_with_missing_production <- function(data,
     )
     paste_write(
       format_indent_1(), "When filtering out holdings with 0 production in relevant sector, dropped rows for",
+      n_companies_pre - n_companies_post, "out of", n_companies_pre, "companies",
+      log_path = log_path
+    )
+    paste_write(format_indent_2(), "percent loss:", percent_loss, log_path = log_path)
+    paste_write(format_indent_2(), "affected companies:", log_path = log_path)
+    purrr::walk(affected_companies, function(company) {
+      paste_write(format_indent_2(), company, log_path = log_path)
+    })
+  }
+
+
+  return(data_filtered)
+}
+
+#' Remove rows from PACTA results that belong to company-sector combinations
+#' for which there is no positive production value in the relevant start year.
+#' This handles the edge case that a company may have a green technology with
+#' zero initial production that should grow over time, but since the overall
+#' sector production is also zero in the start year, the SMSP is unable to
+#' calculate positive targets.
+#'
+#' @inheritParams calculate_annual_profits
+#' @inheritParams report_company_drops
+#' @param data tibble containing filtered PACTA results
+#'
+#' @return A tibble of data without rows with no exposure info
+#' @noRd
+remove_sectors_with_missing_production_start_year <- function(data,
+                                                                   start_year,
+                                                                   log_path) {
+  n_companies_pre <- length(unique(data$company_name))
+
+  companies_missing_sector_production_start_year <- data %>%
+    dplyr::filter(.data$year == .env$start_year) %>%
+    dplyr::group_by(
+      .data$company_name, .data$scenario, .data$ald_sector
+    ) %>%
+    dplyr::summarise(
+      sector_prod = sum(.data$plan_tech_prod, na.rm = TRUE),
+      .groups = "drop"
+    ) %>%
+    dplyr::ungroup() %>%
+    dplyr::filter(.data$sector_prod <= 0)
+
+  # while this technically removes problematic cases for only certain scenarios
+  # for a company, this will in practice not lead to one scenario being removed
+  # and another remaining in the data because the production plans are the same
+  # across scenarios.
+  data_filtered <- data %>%
+    dplyr::anti_join(
+      companies_missing_sector_production_start_year,
+      by = c("company_name", "scenario", "ald_sector")
+    )
+
+  n_companies_post <- length(unique(data_filtered$company_name))
+
+  if (n_companies_pre > n_companies_post) {
+    percent_loss <- (n_companies_pre - n_companies_post) * 100 / n_companies_pre
+    affected_companies <- sort(
+      setdiff(
+        data$company_name,
+        data_filtered$company_name
+      )
+    )
+    paste_write(
+      format_indent_1(), "When filtering out holdings with 0 production in
+      relevant sector in the start year of the analysis, dropped rows for",
+      n_companies_pre - n_companies_post, "out of", n_companies_pre, "companies",
+      log_path = log_path
+    )
+    paste_write(format_indent_2(), "percent loss:", percent_loss, log_path = log_path)
+    paste_write(format_indent_2(), "affected companies:", log_path = log_path)
+    purrr::walk(affected_companies, function(company) {
+      paste_write(format_indent_2(), company, log_path = log_path)
+    })
+  }
+
+
+  return(data_filtered)
+}
+
+#' Remove rows from PACTA results that belong to company-technology combinations
+#' for which there is 0 production in a high carbon technology over the entire
+#' forecast. Since this technology would need to decrease in its targets, the
+#' production remains zero and creates missing values later on. The combination
+#' is therefore removed.
+#'
+#' @inheritParams calculate_annual_profits
+#' @inheritParams report_company_drops
+#' @param data tibble containing filtered PACTA results
+#'
+#' @return A tibble of data without rows with no exposure info
+#' @noRd
+remove_high_carbon_tech_with_missing_production <- function(data,
+                                                   start_year,
+                                                   time_horizon,
+                                                   log_path) {
+  n_companies_pre <- length(unique(data$company_name))
+
+  companies_missing_high_carbon_tech_production <- data %>%
+    dplyr::filter(.data$technology %in% c("ICE", "Coal", "Oil", "Gas", "CoalCap", "GasCap", "OilCap")) %>%
+    dplyr::group_by(
+      .data$company_name, .data$scenario, .data$technology
+    ) %>%
+    dplyr::summarise(
+      technology_prod = sum(.data$plan_tech_prod, na.rm = TRUE),
+      .groups = "drop"
+    ) %>%
+    dplyr::ungroup() %>%
+    dplyr::filter(.data$technology_prod <= 0)
+
+  # while this technically removes problematic cases for only certain scenarios
+  # for a company, this will in practice not lead to one scenario being removed
+  # and another remaining in the data because the production plans are the same
+  # across scenarios.
+  data_filtered <- data %>%
+    dplyr::anti_join(
+      companies_missing_high_carbon_tech_production,
+      by = c("company_name", "scenario", "technology")
+    )
+
+  n_companies_post <- length(unique(data_filtered$company_name))
+
+  if (n_companies_pre > n_companies_post) {
+    percent_loss <- (n_companies_pre - n_companies_post) * 100 / n_companies_pre
+    affected_companies <- sort(
+      setdiff(
+        data$company_name,
+        data_filtered$company_name
+      )
+    )
+    paste_write(
+      format_indent_1(), "When filtering out holdings with 0 production in given high-carbon technology, dropped rows for",
       n_companies_pre - n_companies_post, "out of", n_companies_pre, "companies",
       log_path = log_path
     )

--- a/R/process_data.R
+++ b/R/process_data.R
@@ -345,7 +345,6 @@ remove_high_carbon_tech_with_missing_production <- function(data,
                                                             start_year,
                                                             time_horizon,
                                                             log_path) {
-
   companies_missing_high_carbon_tech_production <- data %>%
     dplyr::filter(.data$technology %in% high_carbon_tech_lookup) %>%
     dplyr::group_by(
@@ -388,9 +387,8 @@ remove_high_carbon_tech_with_missing_production <- function(data,
 
     affected_company_sector_tech_overview %>%
       purrr::pwalk(function(company_name, ald_sector, technology) {
-
-      paste_write(format_indent_2(), "company name:", company_name, "sector:", ald_sector, "technology:", technology, log_path = log_path)
-    })
+        paste_write(format_indent_2(), "company name:", company_name, "sector:", ald_sector, "technology:", technology, log_path = log_path)
+      })
   }
 
   return(data_filtered)

--- a/R/process_data.R
+++ b/R/process_data.R
@@ -348,7 +348,7 @@ remove_high_carbon_tech_with_missing_production <- function(data,
   n_companies_pre <- length(unique(data$company_name))
 
   companies_missing_high_carbon_tech_production <- data %>%
-    dplyr::filter(.data$technology %in% c("ICE", "Coal", "Oil", "Gas", "CoalCap", "GasCap", "OilCap")) %>%
+    dplyr::filter(.data$technology %in% high_carbon_tech_lookup) %>%
     dplyr::group_by(
       .data$company_name, .data$scenario, .data$ald_sector, .data$technology
     ) %>%

--- a/R/process_data.R
+++ b/R/process_data.R
@@ -209,9 +209,9 @@ set_initial_plan_carsten_missings_to_zero <- function(data,
 #' @return A tibble of data without rows with no exposure info
 #' @noRd
 remove_sectors_with_missing_production_end_of_forecast <- function(data,
-                                                   start_year,
-                                                   time_horizon,
-                                                   log_path) {
+                                                                   start_year,
+                                                                   time_horizon,
+                                                                   log_path) {
   n_companies_pre <- length(unique(data$company_name))
 
   companies_missing_sector_production <- data %>%
@@ -276,8 +276,8 @@ remove_sectors_with_missing_production_end_of_forecast <- function(data,
 #' @return A tibble of data without rows with no exposure info
 #' @noRd
 remove_sectors_with_missing_production_start_year <- function(data,
-                                                                   start_year,
-                                                                   log_path) {
+                                                              start_year,
+                                                              log_path) {
   n_companies_pre <- length(unique(data$company_name))
 
   companies_missing_sector_production_start_year <- data %>%
@@ -342,9 +342,9 @@ remove_sectors_with_missing_production_start_year <- function(data,
 #' @return A tibble of data without rows with no exposure info
 #' @noRd
 remove_high_carbon_tech_with_missing_production <- function(data,
-                                                   start_year,
-                                                   time_horizon,
-                                                   log_path) {
+                                                            start_year,
+                                                            time_horizon,
+                                                            log_path) {
   n_companies_pre <- length(unique(data$company_name))
 
   companies_missing_high_carbon_tech_production <- data %>%

--- a/tests/testthat/test-process_data.R
+++ b/tests/testthat/test-process_data.R
@@ -109,3 +109,82 @@ test_that("company with zero production value in the start year across all given
 
   unlink(test_log_path)
 })
+
+test_that("company-tech combination with 0 production in a low carbon technology
+          over entire timeframe is not removed", {
+  test_data <- tibble::tribble(
+    ~year, ~ald_sector, ~technology, ~scenario, ~company_name, ~plan_tech_prod, ~plan_carsten,
+    2020, "Power", "NuclearCap", "scenario_a", "company_x", 0, 0.01,
+    2021, "Power", "NuclearCap", "scenario_a", "company_x", 0, 0.01,
+    2022, "Power", "NuclearCap", "scenario_a", "company_x", 0, 0.01,
+    2023, "Power", "NuclearCap", "scenario_a", "company_x", 0, 0.01,
+    2024, "Power", "NuclearCap", "scenario_a", "company_x", 0, 0.01,
+    2025, "Power", "NuclearCap", "scenario_a", "company_x", 0, 0.01,
+  )
+  test_start_year <- 2020
+  test_time_horizon <- 5
+  test_log_path <- file.path(tempdir(), "log.txt")
+
+  not_removed <- test_data %>%
+    remove_high_carbon_tech_with_missing_production(
+      start_year = test_start_year,
+      time_horizon = test_time_horizon,
+      log_path = test_log_path
+    )
+  testthat::expect_equal(nrow(not_removed), nrow(test_data))
+
+  unlink(test_log_path)
+})
+
+test_that("company-tech combination with positive production in a high carbon
+          technology over parts of the timeframe is not removed", {
+  test_data <- tibble::tribble(
+    ~year, ~ald_sector, ~technology, ~scenario, ~company_name, ~plan_tech_prod, ~plan_carsten,
+    2020, "Power", "OilCap", "scenario_a", "company_x", 0, 0.01,
+    2021, "Power", "OilCap", "scenario_a", "company_x", 0, 0.01,
+    2022, "Power", "OilCap", "scenario_a", "company_x", 0, 0.01,
+    2023, "Power", "OilCap", "scenario_a", "company_x", 1, 0.01,
+    2024, "Power", "OilCap", "scenario_a", "company_x", 1, 0.01,
+    2025, "Power", "OilCap", "scenario_a", "company_x", 1, 0.01,
+  )
+  test_start_year <- 2020
+  test_time_horizon <- 5
+  test_log_path <- file.path(tempdir(), "log.txt")
+
+  not_removed <- test_data %>%
+    remove_high_carbon_tech_with_missing_production(
+      start_year = test_start_year,
+      time_horizon = test_time_horizon,
+      log_path = test_log_path
+    )
+  testthat::expect_equal(nrow(not_removed), nrow(test_data))
+
+  unlink(test_log_path)
+})
+
+test_that("company-tech combination with 0 production in a high carbon technology
+          over entire timeframe is removed", {
+  test_data <- tibble::tribble(
+    ~year, ~ald_sector, ~technology, ~scenario, ~company_name, ~plan_tech_prod, ~plan_carsten,
+    2020, "Power", "OilCap", "scenario_a", "company_x", 0, 0.01,
+    2021, "Power", "OilCap", "scenario_a", "company_x", 0, 0.01,
+    2022, "Power", "OilCap", "scenario_a", "company_x", 0, 0.01,
+    2023, "Power", "OilCap", "scenario_a", "company_x", 0, 0.01,
+    2024, "Power", "OilCap", "scenario_a", "company_x", 0, 0.01,
+    2025, "Power", "OilCap", "scenario_a", "company_x", 0, 0.01,
+  )
+
+  test_start_year <- 2020
+  test_time_horizon <- 5
+  test_log_path <- file.path(tempdir(), "log.txt")
+
+  removed <- test_data %>%
+    remove_high_carbon_tech_with_missing_production(
+      start_year = test_start_year,
+      time_horizon = test_time_horizon,
+      log_path = test_log_path
+    )
+  testthat::expect_equal(nrow(removed), 0)
+
+  unlink(test_log_path)
+})

--- a/tests/testthat/test-process_data.R
+++ b/tests/testthat/test-process_data.R
@@ -13,7 +13,7 @@ test_that("company with positive exposure and production value is not removed", 
   test_log_path <- file.path(tempdir(), "log.txt")
 
   not_removed <- test_data %>%
-    remove_sectors_with_missing_production(
+    remove_sectors_with_missing_production_end_of_forecast(
       start_year = test_start_year,
       time_horizon = test_time_horizon,
       log_path = test_log_path
@@ -39,7 +39,7 @@ test_that("company with positive exposure and zero production value is removed",
   test_log_path <- file.path(tempdir(), "log.txt")
 
   removed <- test_data %>%
-    remove_sectors_with_missing_production(
+    remove_sectors_with_missing_production_end_of_forecast(
       start_year = test_start_year,
       time_horizon = test_time_horizon,
       log_path = test_log_path

--- a/tests/testthat/test-process_data.R
+++ b/tests/testthat/test-process_data.R
@@ -1,4 +1,4 @@
-test_that("company with positive exposure and production value is not removed", {
+test_that("company with positive exposure and production value in final year is not removed", {
   test_data <- tibble::tribble(
     ~year, ~investor_name, ~portfolio_name, ~ald_sector, ~technology, ~scenario, ~scenario_geography, ~company_name, ~plan_tech_prod, ~plan_carsten,
     2020, "investor", "portfolio", "Automotive", "Electric", "scenario_a", "Global", "company_x", 1, 0.01,
@@ -23,7 +23,7 @@ test_that("company with positive exposure and production value is not removed", 
   unlink(test_log_path)
 })
 
-test_that("company with positive exposure and zero production value is removed", {
+test_that("company with positive exposure and zero production value in final year is removed", {
   test_data <- tibble::tribble(
     ~year, ~ald_sector, ~technology, ~scenario, ~company_name, ~plan_tech_prod, ~plan_carsten,
     2020, "Automotive", "Electric", "scenario_a", "company_x", 0, 0.01,
@@ -42,6 +42,67 @@ test_that("company with positive exposure and zero production value is removed",
     remove_sectors_with_missing_production_end_of_forecast(
       start_year = test_start_year,
       time_horizon = test_time_horizon,
+      log_path = test_log_path
+    )
+  testthat::expect_equal(nrow(removed), 0)
+
+  unlink(test_log_path)
+})
+
+test_that("company with positive production value in the start year in at least
+          one technology of a sector is not removed", {
+  test_data <- tibble::tribble(
+    ~year, ~investor_name, ~portfolio_name, ~ald_sector, ~technology, ~scenario, ~scenario_geography, ~company_name, ~plan_tech_prod, ~plan_carsten,
+    2020, "investor", "portfolio", "Automotive", "Electric", "scenario_a", "Global", "company_x", 0, 0,
+    2021, "investor", "portfolio", "Automotive", "Electric", "scenario_a", "Global", "company_x", 1, 0.01,
+    2022, "investor", "portfolio", "Automotive", "Electric", "scenario_a", "Global", "company_x", 1, 0.01,
+    2023, "investor", "portfolio", "Automotive", "Electric", "scenario_a", "Global", "company_x", 1, 0.01,
+    2024, "investor", "portfolio", "Automotive", "Electric", "scenario_a", "Global", "company_x", 1, 0.01,
+    2025, "investor", "portfolio", "Automotive", "Electric", "scenario_a", "Global", "company_x", 1, 0.01,
+    2020, "investor", "portfolio", "Automotive", "ICE", "scenario_a", "Global", "company_x", 1, 0.01,
+    2021, "investor", "portfolio", "Automotive", "ICE", "scenario_a", "Global", "company_x", 1, 0.01,
+    2022, "investor", "portfolio", "Automotive", "ICE", "scenario_a", "Global", "company_x", 1, 0.01,
+    2023, "investor", "portfolio", "Automotive", "ICE", "scenario_a", "Global", "company_x", 1, 0.01,
+    2024, "investor", "portfolio", "Automotive", "ICE", "scenario_a", "Global", "company_x", 1, 0.01,
+    2025, "investor", "portfolio", "Automotive", "ICE", "scenario_a", "Global", "company_x", 1, 0.01
+  )
+  test_start_year <- 2020
+  test_log_path <- file.path(tempdir(), "log.txt")
+
+  not_removed <- test_data %>%
+    remove_sectors_with_missing_production_start_year(
+      start_year = test_start_year,
+      log_path = test_log_path
+    )
+  testthat::expect_equal(nrow(not_removed), nrow(test_data))
+
+  unlink(test_log_path)
+})
+
+test_that("company with zero production value in the start year across all given
+          technologies of a sector is removed", {
+  test_data <- tibble::tribble(
+    ~year, ~ald_sector, ~technology, ~scenario, ~company_name, ~plan_tech_prod, ~plan_carsten,
+    2020, "Automotive", "Electric", "scenario_a", "company_x", 0, 0,
+    2021, "Automotive", "Electric", "scenario_a", "company_x", 1, 0.01,
+    2022, "Automotive", "Electric", "scenario_a", "company_x", 1, 0.01,
+    2023, "Automotive", "Electric", "scenario_a", "company_x", 1, 0.01,
+    2024, "Automotive", "Electric", "scenario_a", "company_x", 1, 0.01,
+    2025, "Automotive", "Electric", "scenario_a", "company_x", 1, 0.01,
+    2020, "Automotive", "ICE", "scenario_a", "company_x", 0, 0,
+    2021, "Automotive", "ICE", "scenario_a", "company_x", 1, 0.01,
+    2022, "Automotive", "ICE", "scenario_a", "company_x", 1, 0.01,
+    2023, "Automotive", "ICE", "scenario_a", "company_x", 1, 0.01,
+    2024, "Automotive", "ICE", "scenario_a", "company_x", 1, 0.01,
+    2025, "Automotive", "ICE", "scenario_a", "company_x", 1, 0.01
+  )
+
+  test_start_year <- 2020
+  test_log_path <- file.path(tempdir(), "log.txt")
+
+  removed <- test_data %>%
+    remove_sectors_with_missing_production_start_year(
+      start_year = test_start_year,
       log_path = test_log_path
     )
   testthat::expect_equal(nrow(removed), 0)

--- a/tests/testthat/test-process_data.R
+++ b/tests/testthat/test-process_data.R
@@ -1,12 +1,12 @@
 test_that("company with positive exposure and production value in final year is not removed", {
   test_data <- tibble::tribble(
-    ~year, ~investor_name, ~portfolio_name, ~ald_sector, ~technology, ~scenario, ~scenario_geography, ~company_name, ~plan_tech_prod, ~plan_carsten,
-    2020, "investor", "portfolio", "Automotive", "Electric", "scenario_a", "Global", "company_x", 1, 0.01,
-    2021, "investor", "portfolio", "Automotive", "Electric", "scenario_a", "Global", "company_x", 1, 0.01,
-    2022, "investor", "portfolio", "Automotive", "Electric", "scenario_a", "Global", "company_x", 1, 0.01,
-    2023, "investor", "portfolio", "Automotive", "Electric", "scenario_a", "Global", "company_x", 1, 0.01,
-    2024, "investor", "portfolio", "Automotive", "Electric", "scenario_a", "Global", "company_x", 1, 0.01,
-    2025, "investor", "portfolio", "Automotive", "Electric", "scenario_a", "Global", "company_x", 1, 0.01,
+    ~year, ~ald_sector, ~technology, ~scenario, ~company_name, ~plan_tech_prod, ~plan_carsten,
+    2020, "Automotive", "Electric", "scenario_a", "company_x", 1, 0.01,
+    2021, "Automotive", "Electric", "scenario_a", "company_x", 1, 0.01,
+    2022, "Automotive", "Electric", "scenario_a", "company_x", 1, 0.01,
+    2023, "Automotive", "Electric", "scenario_a", "company_x", 1, 0.01,
+    2024, "Automotive", "Electric", "scenario_a", "company_x", 1, 0.01,
+    2025, "Automotive", "Electric", "scenario_a", "company_x", 1, 0.01,
   )
   test_start_year <- 2020
   test_time_horizon <- 5
@@ -52,19 +52,19 @@ test_that("company with positive exposure and zero production value in final yea
 test_that("company with positive production value in the start year in at least
           one technology of a sector is not removed", {
   test_data <- tibble::tribble(
-    ~year, ~investor_name, ~portfolio_name, ~ald_sector, ~technology, ~scenario, ~scenario_geography, ~company_name, ~plan_tech_prod, ~plan_carsten,
-    2020, "investor", "portfolio", "Automotive", "Electric", "scenario_a", "Global", "company_x", 0, 0,
-    2021, "investor", "portfolio", "Automotive", "Electric", "scenario_a", "Global", "company_x", 1, 0.01,
-    2022, "investor", "portfolio", "Automotive", "Electric", "scenario_a", "Global", "company_x", 1, 0.01,
-    2023, "investor", "portfolio", "Automotive", "Electric", "scenario_a", "Global", "company_x", 1, 0.01,
-    2024, "investor", "portfolio", "Automotive", "Electric", "scenario_a", "Global", "company_x", 1, 0.01,
-    2025, "investor", "portfolio", "Automotive", "Electric", "scenario_a", "Global", "company_x", 1, 0.01,
-    2020, "investor", "portfolio", "Automotive", "ICE", "scenario_a", "Global", "company_x", 1, 0.01,
-    2021, "investor", "portfolio", "Automotive", "ICE", "scenario_a", "Global", "company_x", 1, 0.01,
-    2022, "investor", "portfolio", "Automotive", "ICE", "scenario_a", "Global", "company_x", 1, 0.01,
-    2023, "investor", "portfolio", "Automotive", "ICE", "scenario_a", "Global", "company_x", 1, 0.01,
-    2024, "investor", "portfolio", "Automotive", "ICE", "scenario_a", "Global", "company_x", 1, 0.01,
-    2025, "investor", "portfolio", "Automotive", "ICE", "scenario_a", "Global", "company_x", 1, 0.01
+    ~year, ~ald_sector, ~technology, ~scenario, ~company_name, ~plan_tech_prod, ~plan_carsten,
+    2020, "Automotive", "Electric", "scenario_a", "company_x", 0, 0,
+    2021, "Automotive", "Electric", "scenario_a", "company_x", 1, 0.01,
+    2022, "Automotive", "Electric", "scenario_a", "company_x", 1, 0.01,
+    2023, "Automotive", "Electric", "scenario_a", "company_x", 1, 0.01,
+    2024, "Automotive", "Electric", "scenario_a", "company_x", 1, 0.01,
+    2025, "Automotive", "Electric", "scenario_a", "company_x", 1, 0.01,
+    2020, "Automotive", "ICE", "scenario_a", "company_x", 1, 0.01,
+    2021, "Automotive", "ICE", "scenario_a", "company_x", 1, 0.01,
+    2022, "Automotive", "ICE", "scenario_a", "company_x", 1, 0.01,
+    2023, "Automotive", "ICE", "scenario_a", "company_x", 1, 0.01,
+    2024, "Automotive", "ICE", "scenario_a", "company_x", 1, 0.01,
+    2025, "Automotive", "ICE", "scenario_a", "company_x", 1, 0.01
   )
   test_start_year <- 2020
   test_log_path <- file.path(tempdir(), "log.txt")


### PR DESCRIPTION
closes ADO 4120

This PR handles edge cases to remove missing values from the company annual profit calculation

Company-sector combinations, for which there is 0 production in the entire sector in the start year of the asset data are removed. This needs to be done because it is impossible to calculate SMSP based targets if there is no sector share to be kept constant.
new function `remove_sectors_with_missing_production_start_year()` in `process_pacta_results()`

Company-technology combinations, for which there is zero production in a high carbon technology across the full forecasting period of the asset data are also removed, since these technologies should be decreasing, but targets below zero are not possible.
new function `remove_high_carbon_tech_with_missing_production()` in `process_pacta_results()`

also renamed `remove_sectors_with_missing_production()` to `remove_sectors_with_missing_production_end_of_forecast()` for consistency

added tests for both new functions

This removed all remaining unexpected NAs