### PR TITLE
remove portfolio level aggregation of results

### DIFF
--- a/R/aggregate_results.R
+++ b/R/aggregate_results.R
@@ -53,7 +53,7 @@ aggregate_results <- function(results_list, sensitivity_analysis_vars, iter_var)
     # aggregate value changes to sector level in given portfolio
     aggregate_value_change_to_sector_level(iter_var = iter_var) %>%
     # aggregate value changes to portfolio level and all covered sectors
-    aggregate_value_change_to_analysed_sectors_and_portfolio(iter_var = iter_var)
+    aggregate_value_change_to_analysed_sectors(iter_var = iter_var)
 
   company_value_changes <- company_value_changes %>%
     dplyr::select(-c(.data$plan_carsten, .data$plan_sec_carsten, .data$year))
@@ -189,7 +189,7 @@ aggregate_value_change_to_sector_level <- function(data, iter_var) {
   return(data)
 }
 
-aggregate_value_change_to_analysed_sectors_and_portfolio <- function(data,
+aggregate_value_change_to_analysed_sectors <- function(data,
                                                                      iter_var) {
   aggregation_vars <- c(
     "investor_name", "portfolio_name", "scenario_geography"
@@ -207,14 +207,7 @@ aggregate_value_change_to_analysed_sectors_and_portfolio <- function(data,
       analysed_sectors_exposure = .data$asset_portfolio_value *
         sum(.data$plan_carsten, na.rm = TRUE),
       analysed_sectors_value_change = .data$analysed_sectors_exposure *
-        .data$VaR_analysed_sectors / 100,
-      portfolio_aum = .data$asset_portfolio_value,
-      # setting portfolio_value_change = analysed_sectors_value_change will
-      # underestimate overall impact on portfolio as there can of course be
-      # impacts on companies in the portfolio that operate in other sectors
-      portfolio_value_change = .data$analysed_sectors_value_change,
-      portfolio_value_change_perc = sum(.data$VaR_tech_company * .data$tech_company_exposure, na.rm = TRUE) /
-        .data$portfolio_aum
+        .data$VaR_analysed_sectors / 100
     ) %>%
     dplyr::ungroup()
 

--- a/R/wrangle_and_check.R
+++ b/R/wrangle_and_check.R
@@ -319,8 +319,7 @@ wrangle_results <- function(results_list, sensitivity_analysis_vars) {
       "technology_exposure", "VaR_technology", "technology_value_change",
       "sector_exposure", "VaR_sector", "sector_value_change",
       "analysed_sectors_exposure", "VaR_analysed_sectors",
-      "analysed_sectors_value_change", "portfolio_aum",
-      "portfolio_value_change_perc", "portfolio_value_change", sensitivity_analysis_vars
+      "analysed_sectors_value_change", sensitivity_analysis_vars
     )
   )
 
@@ -337,8 +336,7 @@ wrangle_results <- function(results_list, sensitivity_analysis_vars) {
       .data$VaR_technology, .data$technology_value_change,
       .data$sector_exposure, .data$VaR_sector, .data$sector_value_change,
       .data$analysed_sectors_exposure, .data$VaR_analysed_sectors,
-      .data$analysed_sectors_value_change, .data$portfolio_aum,
-      .data$portfolio_value_change_perc, .data$portfolio_value_change,
+      .data$analysed_sectors_value_change,
       !!!rlang::syms(sensitivity_analysis_vars)
     ) %>%
     dplyr::rename(
@@ -356,10 +354,7 @@ wrangle_results <- function(results_list, sensitivity_analysis_vars) {
       sector_absolute_value_change = .data$sector_value_change,
       analysed_portfolio_exposure = .data$analysed_sectors_exposure,
       analysed_portfolio_percent_value_change = .data$VaR_analysed_sectors,
-      analysed_portfolio_absolute_value_change = .data$analysed_sectors_value_change,
-      total_portfolio_exposure = .data$portfolio_aum,
-      total_portfolio_percent_value_change = .data$portfolio_value_change_perc,
-      total_portfolio_absolute_value_change = .data$portfolio_value_change
+      analysed_portfolio_absolute_value_change = .data$analysed_sectors_value_change
     )
 
   portfolio_value_changes <- results_list$company_value_changes %>%
@@ -373,8 +368,7 @@ wrangle_results <- function(results_list, sensitivity_analysis_vars) {
       .data$VaR_technology, .data$technology_value_change,
       .data$sector_exposure, .data$VaR_sector, .data$sector_value_change,
       .data$analysed_sectors_exposure, .data$VaR_analysed_sectors,
-      .data$analysed_sectors_value_change, .data$portfolio_aum,
-      .data$portfolio_value_change_perc, .data$portfolio_value_change,
+      .data$analysed_sectors_value_change,
       !!!rlang::syms(sensitivity_analysis_vars)
     ) %>%
     # ADO 2549 - all numeric variables should be unique across the CUC variables
@@ -390,10 +384,7 @@ wrangle_results <- function(results_list, sensitivity_analysis_vars) {
       sector_absolute_value_change = .data$sector_value_change,
       analysed_portfolio_exposure = .data$analysed_sectors_exposure,
       analysed_portfolio_percent_value_change = .data$VaR_analysed_sectors,
-      analysed_portfolio_absolute_value_change = .data$analysed_sectors_value_change,
-      total_portfolio_exposure = .data$portfolio_aum,
-      total_portfolio_percent_value_change = .data$portfolio_value_change_perc,
-      total_portfolio_absolute_value_change = .data$portfolio_value_change
+      analysed_portfolio_absolute_value_change = .data$analysed_sectors_value_change
     )
 
   # expected loss -----------------------------------------------------------


### PR DESCRIPTION
closes ADO4858: https://dev.azure.com/2DegreesInvesting/2DegreesInvesting/_workitems/edit/4858

This PR:
- removes the aggregation of results to the company level (in `aggregate_results` and `wrangle_results`)
- this is required because each scenario only covers certain sectors
- if users need to run the stress test on different scenarios to cover all sectors they want to cover, they should not get conflicting statements on the impact on the total portfolio
- accordingly we only aggregate to the analysed sectors for each run.

Expectations:
- the only changes are that the columns `total_portfolio_exposure, total_portfolio_percent_value_change, total_portfolio_absolute_value_change` are removed from results `*_portfolio_value_changes_standard` and `*_company_value_changes_standard`. all else remains equal

Open:
- check expectations also hold for bonds and loans