### PR TITLE
No unneeded cap fac

### DIFF
--- a/R/calculate.R
+++ b/R/calculate.R
@@ -34,10 +34,6 @@ calculate_annual_profits <- function(asset_type, input_data_list, scenario_to_fo
     )
 
   extended_pacta_results <- input_data_list$pacta_results %>%
-    convert_power_cap_to_generation(
-      capacity_factors_power = input_data_list$capacity_factors_power,
-      baseline_scenario = scenario_to_follow_baseline
-    ) %>%
     extend_scenario_trajectory(
       scenario_data = input_data_list$scenario_data,
       start_analysis = start_year,

--- a/R/process_data.R
+++ b/R/process_data.R
@@ -583,14 +583,17 @@ st_process <- function(data, asset_type, fallback_term,
     asset_type = asset_type
   )
 
-  capacity_factors_power <- process_capacity_factors_power(
-    data$capacity_factors_power,
-    scenarios_filter = scenarios_filter,
-    scenario_geography_filter = scenario_geography,
-    technologies = technologies,
-    start_year = start_year,
-    end_year = end_year_lookup
-  )
+  # capacity_factors are only needed for power sector
+  if ("Power" %in% sectors) {
+    capacity_factors_power <- process_capacity_factors_power(
+      data$capacity_factors_power,
+      scenarios_filter = scenarios_filter,
+      scenario_geography_filter = scenario_geography,
+      technologies = technologies,
+      start_year = start_year,
+      end_year = end_year_lookup
+    )
+  }
 
   df_price <- process_price_data(
     data$df_price,

--- a/R/process_data.R
+++ b/R/process_data.R
@@ -641,7 +641,7 @@ st_process <- function(data, asset_type, fallback_term,
 
     pacta_results <- convert_power_cap_to_generation(
       data = pacta_results,
-      capacity_factors_power = input_data_list$capacity_factors_power,
+      capacity_factors_power = capacity_factors_power,
       baseline_scenario = scenario_to_follow_baseline
     )
   }

--- a/R/process_data.R
+++ b/R/process_data.R
@@ -583,18 +583,6 @@ st_process <- function(data, asset_type, fallback_term,
     asset_type = asset_type
   )
 
-  # capacity_factors are only needed for power sector
-  if ("Power" %in% sectors) {
-    capacity_factors_power <- process_capacity_factors_power(
-      data$capacity_factors_power,
-      scenarios_filter = scenarios_filter,
-      scenario_geography_filter = scenario_geography,
-      technologies = technologies,
-      start_year = start_year,
-      end_year = end_year_lookup
-    )
-  }
-
   df_price <- process_price_data(
     data$df_price,
     technologies = technologies,
@@ -639,6 +627,24 @@ st_process <- function(data, asset_type, fallback_term,
     log_path = log_path
   ) %>%
     add_terms(company_terms = company_terms, fallback_term = fallback_term)
+
+  # capacity_factors are only applied  for power sector
+  if ("Power" %in% sectors) {
+    capacity_factors_power <- process_capacity_factors_power(
+      data$capacity_factors_power,
+      scenarios_filter = scenarios_filter,
+      scenario_geography_filter = scenario_geography,
+      technologies = technologies,
+      start_year = start_year,
+      end_year = end_year_lookup
+    )
+
+    pacta_results <- convert_power_cap_to_generation(
+      data = pacta_results,
+      capacity_factors_power = input_data_list$capacity_factors_power,
+      baseline_scenario = scenario_to_follow_baseline
+    )
+  }
 
   out <- list(
     pacta_results = pacta_results,

--- a/R/process_data.R
+++ b/R/process_data.R
@@ -642,7 +642,7 @@ st_process <- function(data, asset_type, fallback_term,
     pacta_results <- convert_power_cap_to_generation(
       data = pacta_results,
       capacity_factors_power = capacity_factors_power,
-      baseline_scenario = scenario_to_follow_baseline
+      baseline_scenario = baseline_scenario
     )
   }
 

--- a/R/read.R
+++ b/R/read.R
@@ -8,9 +8,17 @@ st_read_specific <- function(dir, asset_type, use_company_terms) {
   return(out)
 }
 
-st_read_agnostic <- function(dir, start_year) {
+st_read_agnostic <- function(dir, start_year, sectors) {
+
+  # capacity_factors are only needed for power sector
+  if ("Power" %in% sectors) {
+    capacity_factors_power <- read_capacity_factors_power(capacity_factor_file(dir))
+  } else {
+    capacity_factors_power <- NULL
+  }
+
   out <- list(
-    capacity_factors_power = read_capacity_factors_power(capacity_factor_file(dir)),
+    capacity_factors_power = capacity_factors_power,
     df_price = read_price_data(price_data_file(dir)),
     scenario_data = read_scenario_data(scenario_data_file(dir, start_year)),
     financial_data = read_financial_data(financial_data_file(dir))

--- a/R/run_stress_test.R
+++ b/R/run_stress_test.R
@@ -188,6 +188,8 @@ read_and_process_and_calc <- function(args_list) {
     lgd_subordinated_claims = lgd_subordinated_claims
   )
 
+  sectors_and_technologies_list <- infer_sectors_and_technologies(scenario_geography)
+
   cat("-- Reading input data from designated input path. \n")
 
   if (use_company_terms) {
@@ -201,12 +203,10 @@ read_and_process_and_calc <- function(args_list) {
   )
   start_year <- get_start_year(data)
   data <- append(
-    data, st_read_agnostic(input_path_project_agnostic, start_year = start_year)
+    data, st_read_agnostic(input_path_project_agnostic, start_year = start_year, sectors = sectors_and_technologies_list$sectors)
   )
 
   cat("-- Processing input data. \n")
-
-  sectors_and_technologies_list <- infer_sectors_and_technologies(scenario_geography)
 
   processed <- data %>%
     st_process(


### PR DESCRIPTION

This is another preparatory PR for https://dev.azure.com/2DegreesInvesting/2DegreesInvesting/_workitems/edit/3129
It makes sure that capacity_factors are only imported, wrangled etc. if they are actually needed. To make this simpler I moved the conversion from cap to generation to data preprocessing, where it logically make also more sense IMO.
Snapshot tests passed (expectation: No changes)