### PR TITLE
rm uneeded function

### DIFF
--- a/R/wrangle_and_check.R
+++ b/R/wrangle_and_check.R
@@ -228,8 +228,7 @@ wrangle_scenario_data <- function(scenario_data, start_year, end_year) {
     dplyr::rename(source = .data$scenario_source) %>%
     dplyr::filter(.data$source %in% c("ETP2017", "WEO2019")) %>%
     dplyr::filter(!(.data$source == "ETP2017" & .data$ald_sector == "Power")) %>%
-    dplyr::mutate(scenario = ifelse(stringr::str_detect(.data$scenario, "_"), stringr::str_extract(.data$scenario, "[^_]*$"), .data$scenario)) %>%
-    check_scenario_timeframe(start_year = start_year, end_year = end_year)
+    dplyr::mutate(scenario = ifelse(stringr::str_detect(.data$scenario, "_"), stringr::str_extract(.data$scenario, "[^_]*$"), .data$scenario))
   return(scenario_data_wrangled)
 }
 


### PR DESCRIPTION
super small PR to make diff for scenerio flex smaller. We do not need this function as this is already checked here: https://github.com/2DegreesInvesting/r2dii.climate.stress.test/blob/3964bc57c67133e50197699d7412d03e4958dc9f/R/process_data.R#L519