### PR TITLE
Lrisk parameters to output

### DIFF
--- a/R/aggregate_results.R
+++ b/R/aggregate_results.R
@@ -34,7 +34,7 @@ aggregate_results <- function(results_list, sensitivity_analysis_vars, iter_var,
 
   if (risk_type == "lrisk") {
     lrisk_additional <- c("scc_arg", "settlement_factor_arg", "exp_share_damages_paid_arg")
-    merge_by_cols <- append(merge_by_cols, lrisk_additional)
+    merge_by_cols <- c(merge_by_cols, lrisk_additional)
   }
 
   crispy_output <- results_list$company_technology_npv %>%
@@ -109,7 +109,6 @@ aggregate_results <- function(results_list, sensitivity_analysis_vars, iter_var,
         .data$term, .data$pd_baseline, .data$pd_shock, .data$pd_difference
       )
   }
-
 
   return(list(
     company_trajectories = results_list$company_trajectories,

--- a/R/aggregate_results.R
+++ b/R/aggregate_results.R
@@ -30,7 +30,8 @@ aggregate_results <- function(results_list, sensitivity_analysis_vars, iter_var)
         "investor_name", "portfolio_name", "scenario_name", "scenario_geography",
         "company_name", "ald_sector", "asset_type_arg", "baseline_scenario_arg",
         "shock_scenario_arg", "lgd_arg", "risk_free_rate_arg", "discount_rate_arg",
-        "growth_rate_arg", "div_netprofit_prop_coef_arg", "shock_year_arg",
+        "growth_rate_arg", "scc_arg", "settlement_factor_arg", "exp_share_damages_paid_arg",
+        "div_netprofit_prop_coef_arg", "shock_year_arg",
         "fallback_term_arg", "use_company_terms_arg"
       )
     )
@@ -53,6 +54,9 @@ aggregate_results <- function(results_list, sensitivity_analysis_vars, iter_var)
       discount_rate = .data$discount_rate_arg,
       dividend_rate = .data$div_netprofit_prop_coef_arg,
       growth_rate = .data$growth_rate_arg,
+      scc = .data$scc_arg,
+      settlement_factor = .data$settlement_factor_arg,
+      exp_share_damages_paid = .data$exp_share_damages_paid_arg,
       shock_year = .data$shock_year_arg,
       net_present_value_baseline = .data$total_disc_npv_baseline,
       net_present_value_shock = .data$total_disc_npv_ls,
@@ -68,7 +72,8 @@ aggregate_results <- function(results_list, sensitivity_analysis_vars, iter_var)
       .data$roll_up_type, .data$scenario_geography, .data$calculation_type,
       .data$baseline_scenario, .data$shock_scenario, .data$lgd,
       .data$risk_free_rate, .data$discount_rate, .data$dividend_rate,
-      .data$growth_rate, .data$shock_year, .data$net_present_value_baseline,
+      .data$growth_rate, .data$scc, .data$settlement_factor, .data$exp_share_damages_paid,
+      .data$shock_year, .data$net_present_value_baseline,
       .data$net_present_value_shock, .data$net_present_value_difference,
       .data$term, .data$pd_baseline, .data$pd_shock, .data$pd_difference
     )

--- a/R/aggregate_results.R
+++ b/R/aggregate_results.R
@@ -24,14 +24,15 @@ aggregate_results <- function(results_list, sensitivity_analysis_vars, iter_var,
 
   # Aggregate Crispy Results -----
 
-  merge_by_cols <- c("investor_name", "portfolio_name", "scenario_name", "scenario_geography",
-                     "company_name", "ald_sector", "asset_type_arg", "baseline_scenario_arg",
-                     "shock_scenario_arg", "lgd_arg", "risk_free_rate_arg", "discount_rate_arg",
-                     "growth_rate_arg", "div_netprofit_prop_coef_arg", "shock_year_arg",
-                     "fallback_term_arg", "use_company_terms_arg")
+  merge_by_cols <- c(
+    "investor_name", "portfolio_name", "scenario_name", "scenario_geography",
+    "company_name", "ald_sector", "asset_type_arg", "baseline_scenario_arg",
+    "shock_scenario_arg", "lgd_arg", "risk_free_rate_arg", "discount_rate_arg",
+    "growth_rate_arg", "div_netprofit_prop_coef_arg", "shock_year_arg",
+    "fallback_term_arg", "use_company_terms_arg"
+  )
 
   if (risk_type == "lrisk") {
-
     lrisk_additional <- c("scc_arg", "settlement_factor_arg", "exp_share_damages_paid_arg")
     merge_by_cols <- append(merge_by_cols, lrisk_additional)
   }
@@ -74,17 +75,17 @@ aggregate_results <- function(results_list, sensitivity_analysis_vars, iter_var,
       dplyr::rename(
         scc = .data$scc_arg,
         settlement_factor = .data$settlement_factor_arg,
-        exp_share_damages_paid = .data$exp_share_damages_paid_arg)
+        exp_share_damages_paid = .data$exp_share_damages_paid_arg
+      )
   }
 
   crispy_output <- crispy_output %>%
-      dplyr::mutate(
-        net_present_value_difference = .data$net_present_value_shock - .data$net_present_value_baseline,
-        pd_difference = .data$pd_shock - .data$pd_baseline
-      )
+    dplyr::mutate(
+      net_present_value_difference = .data$net_present_value_shock - .data$net_present_value_baseline,
+      pd_difference = .data$pd_shock - .data$pd_baseline
+    )
 
   if (risk_type == "lrisk") {
-
     crispy_output <- crispy_output %>%
       dplyr::select(
         .data$company_name, .data$sector, .data$business_unit,
@@ -94,21 +95,19 @@ aggregate_results <- function(results_list, sensitivity_analysis_vars, iter_var,
         .data$growth_rate, .data$scc, .data$settlement_factor, .data$exp_share_damages_paid,
         .data$shock_year, .data$net_present_value_baseline,
         .data$net_present_value_shock, .data$net_present_value_difference,
-        .data$term, .data$pd_baseline, .data$pd_shock, .data$pd_difference)
-  }
-  else {
-
+        .data$term, .data$pd_baseline, .data$pd_shock, .data$pd_difference
+      )
+  } else {
     crispy_output <- crispy_output %>%
       dplyr::select(
         .data$company_name, .data$sector, .data$business_unit,
         .data$roll_up_type, .data$scenario_geography, .data$calculation_type,
         .data$baseline_scenario, .data$shock_scenario, .data$lgd,
         .data$risk_free_rate, .data$discount_rate, .data$dividend_rate,
-        .data$growth_rate,.data$shock_year, .data$net_present_value_baseline,
+        .data$growth_rate, .data$shock_year, .data$net_present_value_baseline,
         .data$net_present_value_shock, .data$net_present_value_difference,
-        .data$term, .data$pd_baseline, .data$pd_shock, .data$pd_difference)
-
-
+        .data$term, .data$pd_baseline, .data$pd_shock, .data$pd_difference
+      )
   }
 
 

--- a/R/aggregate_results.R
+++ b/R/aggregate_results.R
@@ -32,25 +32,25 @@ aggregate_results <- function(results_list, sensitivity_analysis_vars, iter_var,
           "investor_name", "portfolio_name", "scenario_name", "scenario_geography",
           "company_name", "ald_sector", "asset_type_arg", "baseline_scenario_arg",
           "shock_scenario_arg", "lgd_arg", "risk_free_rate_arg", "discount_rate_arg",
-          "growth_rate_arg","div_netprofit_prop_coef_arg", "shock_year_arg",
+          "growth_rate_arg", "div_netprofit_prop_coef_arg", "shock_year_arg",
           "fallback_term_arg", "use_company_terms_arg"
         )
       )
   }
 
   if (risk_type == "lrisk") {
-  crispy_output <- results_list$company_technology_npv %>%
-    dplyr::inner_join(
-      results_list$company_pd_changes_overall,
-      by = c(
-        "investor_name", "portfolio_name", "scenario_name", "scenario_geography",
-        "company_name", "ald_sector", "asset_type_arg", "baseline_scenario_arg",
-        "shock_scenario_arg", "lgd_arg", "risk_free_rate_arg", "discount_rate_arg",
-        "growth_rate_arg", "scc_arg", "settlement_factor_arg", "exp_share_damages_paid_arg",
-        "div_netprofit_prop_coef_arg", "shock_year_arg",
-        "fallback_term_arg", "use_company_terms_arg"
+    crispy_output <- results_list$company_technology_npv %>%
+      dplyr::inner_join(
+        results_list$company_pd_changes_overall,
+        by = c(
+          "investor_name", "portfolio_name", "scenario_name", "scenario_geography",
+          "company_name", "ald_sector", "asset_type_arg", "baseline_scenario_arg",
+          "shock_scenario_arg", "lgd_arg", "risk_free_rate_arg", "discount_rate_arg",
+          "growth_rate_arg", "scc_arg", "settlement_factor_arg", "exp_share_damages_paid_arg",
+          "div_netprofit_prop_coef_arg", "shock_year_arg",
+          "fallback_term_arg", "use_company_terms_arg"
+        )
       )
-    )
   }
   crispy_output <- crispy_output %>%
     dplyr::mutate(
@@ -92,45 +92,43 @@ aggregate_results <- function(results_list, sensitivity_analysis_vars, iter_var,
         .data$net_present_value_shock, .data$net_present_value_difference,
         .data$term, .data$pd_baseline, .data$pd_shock, .data$pd_difference
       )
-
   }
 
   if (risk_type == "lrisk") {
-  crispy_output <- crispy_output %>%
-    dplyr::rename(
-      sector = .data$ald_sector,
-      business_unit = .data$technology,
-      calculation_type = .data$asset_type_arg,
-      baseline_scenario = .data$baseline_scenario_arg,
-      shock_scenario = .data$shock_scenario_arg,
-      lgd = .data$lgd_arg,
-      discount_rate = .data$discount_rate_arg,
-      dividend_rate = .data$div_netprofit_prop_coef_arg,
-      growth_rate = .data$growth_rate_arg,
-      scc = .data$scc_arg,
-      settlement_factor = .data$settlement_factor_arg,
-      exp_share_damages_paid = .data$exp_share_damages_paid_arg,
-      shock_year = .data$shock_year_arg,
-      net_present_value_baseline = .data$total_disc_npv_baseline,
-      net_present_value_shock = .data$total_disc_npv_ls,
-      pd_baseline = .data$PD_baseline,
-      pd_shock = .data$PD_late_sudden
-    ) %>%
-    dplyr::mutate(
-      net_present_value_difference = .data$net_present_value_shock - .data$net_present_value_baseline,
-      pd_difference = .data$pd_shock - .data$pd_baseline
-    ) %>%
-    dplyr::select(
-      .data$company_name, .data$sector, .data$business_unit,
-      .data$roll_up_type, .data$scenario_geography, .data$calculation_type,
-      .data$baseline_scenario, .data$shock_scenario, .data$lgd,
-      .data$risk_free_rate, .data$discount_rate, .data$dividend_rate,
-      .data$growth_rate, .data$scc, .data$settlement_factor, .data$exp_share_damages_paid,
-      .data$shock_year, .data$net_present_value_baseline,
-      .data$net_present_value_shock, .data$net_present_value_difference,
-      .data$term, .data$pd_baseline, .data$pd_shock, .data$pd_difference
-    )
-
+    crispy_output <- crispy_output %>%
+      dplyr::rename(
+        sector = .data$ald_sector,
+        business_unit = .data$technology,
+        calculation_type = .data$asset_type_arg,
+        baseline_scenario = .data$baseline_scenario_arg,
+        shock_scenario = .data$shock_scenario_arg,
+        lgd = .data$lgd_arg,
+        discount_rate = .data$discount_rate_arg,
+        dividend_rate = .data$div_netprofit_prop_coef_arg,
+        growth_rate = .data$growth_rate_arg,
+        scc = .data$scc_arg,
+        settlement_factor = .data$settlement_factor_arg,
+        exp_share_damages_paid = .data$exp_share_damages_paid_arg,
+        shock_year = .data$shock_year_arg,
+        net_present_value_baseline = .data$total_disc_npv_baseline,
+        net_present_value_shock = .data$total_disc_npv_ls,
+        pd_baseline = .data$PD_baseline,
+        pd_shock = .data$PD_late_sudden
+      ) %>%
+      dplyr::mutate(
+        net_present_value_difference = .data$net_present_value_shock - .data$net_present_value_baseline,
+        pd_difference = .data$pd_shock - .data$pd_baseline
+      ) %>%
+      dplyr::select(
+        .data$company_name, .data$sector, .data$business_unit,
+        .data$roll_up_type, .data$scenario_geography, .data$calculation_type,
+        .data$baseline_scenario, .data$shock_scenario, .data$lgd,
+        .data$risk_free_rate, .data$discount_rate, .data$dividend_rate,
+        .data$growth_rate, .data$scc, .data$settlement_factor, .data$exp_share_damages_paid,
+        .data$shock_year, .data$net_present_value_baseline,
+        .data$net_present_value_shock, .data$net_present_value_difference,
+        .data$term, .data$pd_baseline, .data$pd_shock, .data$pd_difference
+      )
   }
 
   return(list(

--- a/R/aggregate_results.R
+++ b/R/aggregate_results.R
@@ -16,13 +16,29 @@
 #'   arguments.
 #' @param iter_var String vector holding the variable over which to iterate in
 #'   sensitivity analysis
+#' @param risk_type String that is either lrisk or trisk
 #'
 #' @return A list including basic and aggregated results.
-aggregate_results <- function(results_list, sensitivity_analysis_vars, iter_var) {
+aggregate_results <- function(results_list, sensitivity_analysis_vars, iter_var, risk_type) {
   sensitivity_analysis_vars <- paste0(sensitivity_analysis_vars, "_arg")
 
   # Aggregate Crispy Results -----
 
+  if (risk_type == "trisk") {
+    crispy_output <- results_list$company_technology_npv %>%
+      dplyr::inner_join(
+        results_list$company_pd_changes_overall,
+        by = c(
+          "investor_name", "portfolio_name", "scenario_name", "scenario_geography",
+          "company_name", "ald_sector", "asset_type_arg", "baseline_scenario_arg",
+          "shock_scenario_arg", "lgd_arg", "risk_free_rate_arg", "discount_rate_arg",
+          "growth_rate_arg","div_netprofit_prop_coef_arg", "shock_year_arg",
+          "fallback_term_arg", "use_company_terms_arg"
+        )
+      )
+  }
+
+  if (risk_type == "lrisk") {
   crispy_output <- results_list$company_technology_npv %>%
     dplyr::inner_join(
       results_list$company_pd_changes_overall,
@@ -35,7 +51,7 @@ aggregate_results <- function(results_list, sensitivity_analysis_vars, iter_var)
         "fallback_term_arg", "use_company_terms_arg"
       )
     )
-
+  }
   crispy_output <- crispy_output %>%
     dplyr::mutate(
       roll_up_type = dplyr::if_else(
@@ -43,7 +59,44 @@ aggregate_results <- function(results_list, sensitivity_analysis_vars, iter_var)
         "financial_control",
         "equity_ownership"
       )
-    ) %>%
+    )
+
+  if (risk_type == "trisk") {
+    crispy_output <- crispy_output %>%
+      dplyr::rename(
+        sector = .data$ald_sector,
+        business_unit = .data$technology,
+        calculation_type = .data$asset_type_arg,
+        baseline_scenario = .data$baseline_scenario_arg,
+        shock_scenario = .data$shock_scenario_arg,
+        lgd = .data$lgd_arg,
+        discount_rate = .data$discount_rate_arg,
+        dividend_rate = .data$div_netprofit_prop_coef_arg,
+        growth_rate = .data$growth_rate_arg,
+        shock_year = .data$shock_year_arg,
+        net_present_value_baseline = .data$total_disc_npv_baseline,
+        net_present_value_shock = .data$total_disc_npv_ls,
+        pd_baseline = .data$PD_baseline,
+        pd_shock = .data$PD_late_sudden
+      ) %>%
+      dplyr::mutate(
+        net_present_value_difference = .data$net_present_value_shock - .data$net_present_value_baseline,
+        pd_difference = .data$pd_shock - .data$pd_baseline
+      ) %>%
+      dplyr::select(
+        .data$company_name, .data$sector, .data$business_unit,
+        .data$roll_up_type, .data$scenario_geography, .data$calculation_type,
+        .data$baseline_scenario, .data$shock_scenario, .data$lgd,
+        .data$risk_free_rate, .data$discount_rate, .data$dividend_rate,
+        .data$growth_rate, .data$shock_year, .data$net_present_value_baseline,
+        .data$net_present_value_shock, .data$net_present_value_difference,
+        .data$term, .data$pd_baseline, .data$pd_shock, .data$pd_difference
+      )
+
+  }
+
+  if (risk_type == "lrisk") {
+  crispy_output <- crispy_output %>%
     dplyr::rename(
       sector = .data$ald_sector,
       business_unit = .data$technology,
@@ -77,6 +130,8 @@ aggregate_results <- function(results_list, sensitivity_analysis_vars, iter_var)
       .data$net_present_value_shock, .data$net_present_value_difference,
       .data$term, .data$pd_baseline, .data$pd_shock, .data$pd_difference
     )
+
+  }
 
   return(list(
     company_trajectories = results_list$company_trajectories,

--- a/R/aggregate_results.R
+++ b/R/aggregate_results.R
@@ -24,34 +24,24 @@ aggregate_results <- function(results_list, sensitivity_analysis_vars, iter_var,
 
   # Aggregate Crispy Results -----
 
-  if (risk_type == "trisk") {
-    crispy_output <- results_list$company_technology_npv %>%
-      dplyr::inner_join(
-        results_list$company_pd_changes_overall,
-        by = c(
-          "investor_name", "portfolio_name", "scenario_name", "scenario_geography",
-          "company_name", "ald_sector", "asset_type_arg", "baseline_scenario_arg",
-          "shock_scenario_arg", "lgd_arg", "risk_free_rate_arg", "discount_rate_arg",
-          "growth_rate_arg", "div_netprofit_prop_coef_arg", "shock_year_arg",
-          "fallback_term_arg", "use_company_terms_arg"
-        )
-      )
-  }
+  merge_by_cols <- c("investor_name", "portfolio_name", "scenario_name", "scenario_geography",
+                     "company_name", "ald_sector", "asset_type_arg", "baseline_scenario_arg",
+                     "shock_scenario_arg", "lgd_arg", "risk_free_rate_arg", "discount_rate_arg",
+                     "growth_rate_arg", "div_netprofit_prop_coef_arg", "shock_year_arg",
+                     "fallback_term_arg", "use_company_terms_arg")
 
   if (risk_type == "lrisk") {
-    crispy_output <- results_list$company_technology_npv %>%
-      dplyr::inner_join(
-        results_list$company_pd_changes_overall,
-        by = c(
-          "investor_name", "portfolio_name", "scenario_name", "scenario_geography",
-          "company_name", "ald_sector", "asset_type_arg", "baseline_scenario_arg",
-          "shock_scenario_arg", "lgd_arg", "risk_free_rate_arg", "discount_rate_arg",
-          "growth_rate_arg", "scc_arg", "settlement_factor_arg", "exp_share_damages_paid_arg",
-          "div_netprofit_prop_coef_arg", "shock_year_arg",
-          "fallback_term_arg", "use_company_terms_arg"
-        )
-      )
+
+    lrisk_additional <- c("scc_arg", "settlement_factor_arg", "exp_share_damages_paid_arg")
+    merge_by_cols <- append(merge_by_cols, lrisk_additional)
   }
+
+  crispy_output <- results_list$company_technology_npv %>%
+    dplyr::inner_join(
+      results_list$company_pd_changes_overall,
+      by = merge_by_cols
+    )
+
   crispy_output <- crispy_output %>%
     dplyr::mutate(
       roll_up_type = dplyr::if_else(
@@ -61,64 +51,41 @@ aggregate_results <- function(results_list, sensitivity_analysis_vars, iter_var,
       )
     )
 
-  if (risk_type == "trisk") {
-    crispy_output <- crispy_output %>%
-      dplyr::rename(
-        sector = .data$ald_sector,
-        business_unit = .data$technology,
-        calculation_type = .data$asset_type_arg,
-        baseline_scenario = .data$baseline_scenario_arg,
-        shock_scenario = .data$shock_scenario_arg,
-        lgd = .data$lgd_arg,
-        discount_rate = .data$discount_rate_arg,
-        dividend_rate = .data$div_netprofit_prop_coef_arg,
-        growth_rate = .data$growth_rate_arg,
-        shock_year = .data$shock_year_arg,
-        net_present_value_baseline = .data$total_disc_npv_baseline,
-        net_present_value_shock = .data$total_disc_npv_ls,
-        pd_baseline = .data$PD_baseline,
-        pd_shock = .data$PD_late_sudden
-      ) %>%
-      dplyr::mutate(
-        net_present_value_difference = .data$net_present_value_shock - .data$net_present_value_baseline,
-        pd_difference = .data$pd_shock - .data$pd_baseline
-      ) %>%
-      dplyr::select(
-        .data$company_name, .data$sector, .data$business_unit,
-        .data$roll_up_type, .data$scenario_geography, .data$calculation_type,
-        .data$baseline_scenario, .data$shock_scenario, .data$lgd,
-        .data$risk_free_rate, .data$discount_rate, .data$dividend_rate,
-        .data$growth_rate, .data$shock_year, .data$net_present_value_baseline,
-        .data$net_present_value_shock, .data$net_present_value_difference,
-        .data$term, .data$pd_baseline, .data$pd_shock, .data$pd_difference
-      )
-  }
+  crispy_output <- crispy_output %>%
+    dplyr::rename(
+      sector = .data$ald_sector,
+      business_unit = .data$technology,
+      calculation_type = .data$asset_type_arg,
+      baseline_scenario = .data$baseline_scenario_arg,
+      shock_scenario = .data$shock_scenario_arg,
+      lgd = .data$lgd_arg,
+      discount_rate = .data$discount_rate_arg,
+      dividend_rate = .data$div_netprofit_prop_coef_arg,
+      growth_rate = .data$growth_rate_arg,
+      shock_year = .data$shock_year_arg,
+      net_present_value_baseline = .data$total_disc_npv_baseline,
+      net_present_value_shock = .data$total_disc_npv_ls,
+      pd_baseline = .data$PD_baseline,
+      pd_shock = .data$PD_late_sudden
+    )
 
   if (risk_type == "lrisk") {
     crispy_output <- crispy_output %>%
       dplyr::rename(
-        sector = .data$ald_sector,
-        business_unit = .data$technology,
-        calculation_type = .data$asset_type_arg,
-        baseline_scenario = .data$baseline_scenario_arg,
-        shock_scenario = .data$shock_scenario_arg,
-        lgd = .data$lgd_arg,
-        discount_rate = .data$discount_rate_arg,
-        dividend_rate = .data$div_netprofit_prop_coef_arg,
-        growth_rate = .data$growth_rate_arg,
         scc = .data$scc_arg,
         settlement_factor = .data$settlement_factor_arg,
-        exp_share_damages_paid = .data$exp_share_damages_paid_arg,
-        shock_year = .data$shock_year_arg,
-        net_present_value_baseline = .data$total_disc_npv_baseline,
-        net_present_value_shock = .data$total_disc_npv_ls,
-        pd_baseline = .data$PD_baseline,
-        pd_shock = .data$PD_late_sudden
-      ) %>%
+        exp_share_damages_paid = .data$exp_share_damages_paid_arg)
+  }
+
+  crispy_output <- crispy_output %>%
       dplyr::mutate(
         net_present_value_difference = .data$net_present_value_shock - .data$net_present_value_baseline,
         pd_difference = .data$pd_shock - .data$pd_baseline
-      ) %>%
+      )
+
+  if (risk_type == "lrisk") {
+
+    crispy_output <- crispy_output %>%
       dplyr::select(
         .data$company_name, .data$sector, .data$business_unit,
         .data$roll_up_type, .data$scenario_geography, .data$calculation_type,
@@ -127,9 +94,23 @@ aggregate_results <- function(results_list, sensitivity_analysis_vars, iter_var,
         .data$growth_rate, .data$scc, .data$settlement_factor, .data$exp_share_damages_paid,
         .data$shock_year, .data$net_present_value_baseline,
         .data$net_present_value_shock, .data$net_present_value_difference,
-        .data$term, .data$pd_baseline, .data$pd_shock, .data$pd_difference
-      )
+        .data$term, .data$pd_baseline, .data$pd_shock, .data$pd_difference)
   }
+  else {
+
+    crispy_output <- crispy_output %>%
+      dplyr::select(
+        .data$company_name, .data$sector, .data$business_unit,
+        .data$roll_up_type, .data$scenario_geography, .data$calculation_type,
+        .data$baseline_scenario, .data$shock_scenario, .data$lgd,
+        .data$risk_free_rate, .data$discount_rate, .data$dividend_rate,
+        .data$growth_rate,.data$shock_year, .data$net_present_value_baseline,
+        .data$net_present_value_shock, .data$net_present_value_difference,
+        .data$term, .data$pd_baseline, .data$pd_shock, .data$pd_difference)
+
+
+  }
+
 
   return(list(
     company_trajectories = results_list$company_trajectories,

--- a/R/run_lrisk.R
+++ b/R/run_lrisk.R
@@ -125,7 +125,8 @@ run_lrisk <- function(asset_type,
   st_results_aggregated <- aggregate_results(
     results_list = st_results,
     sensitivity_analysis_vars = names(args_list)[!names(args_list) %in% setup_vars_lookup],
-    iter_var = iter_var
+    iter_var = iter_var,
+    risk_type = "lrisk"
   )
 
   st_results_wrangled_and_checked <- wrangle_results(
@@ -133,7 +134,8 @@ run_lrisk <- function(asset_type,
     sensitivity_analysis_vars = names(args_list)[!names(args_list) %in% setup_vars_lookup]
   ) %>%
     check_results(
-      sensitivity_analysis_vars = names(args_list)[!names(args_list) %in% setup_vars_lookup]
+      sensitivity_analysis_vars = names(args_list)[!names(args_list) %in% setup_vars_lookup],
+      risk_type = "lrisk"
     )
 
   if (return_results) {

--- a/R/run_trisk.R
+++ b/R/run_trisk.R
@@ -109,7 +109,8 @@ run_trisk <- function(asset_type,
   st_results_aggregated <- aggregate_results(
     results_list = st_results,
     sensitivity_analysis_vars = names(args_list)[!names(args_list) %in% setup_vars_lookup],
-    iter_var = iter_var
+    iter_var = iter_var,
+    risk_type = "trisk"
   )
 
   st_results_wrangled_and_checked <- wrangle_results(
@@ -117,7 +118,8 @@ run_trisk <- function(asset_type,
     sensitivity_analysis_vars = names(args_list)[!names(args_list) %in% setup_vars_lookup]
   ) %>%
     check_results(
-      sensitivity_analysis_vars = names(args_list)[!names(args_list) %in% setup_vars_lookup]
+      sensitivity_analysis_vars = names(args_list)[!names(args_list) %in% setup_vars_lookup],
+      risk_type = "trisk"
     )
 
   if (return_results) {

--- a/R/wrangle_and_check.R
+++ b/R/wrangle_and_check.R
@@ -292,7 +292,7 @@ check_results <- function(wrangled_results_list, sensitivity_analysis_vars, risk
   wrangled_results_list$crispy_output %>%
     report_missings(
       name_data = "CRISPY Results"
-    ) #%>%
+    )
 
   if (risk_type == "trisk") {
     wrangled_results_list$crispy_output <- wrangled_results_list$crispy_output %>%
@@ -307,16 +307,16 @@ check_results <- function(wrangled_results_list, sensitivity_analysis_vars, risk
   }
 
   if (risk_type == "lrisk") {
-  wrangled_results_list$crispy_output <- wrangled_results_list$crispy_output %>%
-    report_all_duplicate_kinds(
-      composite_unique_cols = c(
-        "company_name", "sector", "business_unit", "roll_up_type",
-        "scenario_geography", "calculation_type", "baseline_scenario",
-        "shock_scenario", "lgd", "risk_free_rate", "discount_rate",
-        "dividend_rate", "growth_rate", "shock_year", "term",
-        "scc","settlement_factor", "exp_share_damages_paid"
+    wrangled_results_list$crispy_output <- wrangled_results_list$crispy_output %>%
+      report_all_duplicate_kinds(
+        composite_unique_cols = c(
+          "company_name", "sector", "business_unit", "roll_up_type",
+          "scenario_geography", "calculation_type", "baseline_scenario",
+          "shock_scenario", "lgd", "risk_free_rate", "discount_rate",
+          "dividend_rate", "growth_rate", "shock_year", "term",
+          "scc", "settlement_factor", "exp_share_damages_paid"
+        )
       )
-    )
   }
   return(invisible(wrangled_results_list))
 }

--- a/R/wrangle_and_check.R
+++ b/R/wrangle_and_check.R
@@ -297,7 +297,8 @@ check_results <- function(wrangled_results_list, sensitivity_analysis_vars) {
         "company_name", "sector", "business_unit", "roll_up_type",
         "scenario_geography", "calculation_type", "baseline_scenario",
         "shock_scenario", "lgd", "risk_free_rate", "discount_rate",
-        "dividend_rate", "growth_rate", "shock_year", "term"
+        "dividend_rate", "growth_rate", "shock_year", "term", "scc",
+        "settlement_factor", "exp_share_damages_paid"
       )
     )
 

--- a/R/wrangle_and_check.R
+++ b/R/wrangle_and_check.R
@@ -261,9 +261,10 @@ wrangle_results <- function(results_list, sensitivity_analysis_vars) {
 #'
 #' @inheritParams wrangle_results
 #' @param wrangled_results_list A list of wrangled results.
+#' @param risk_type String that is either lrisk or trisk.
 #'
 #' @return `wrangled_results_list`
-check_results <- function(wrangled_results_list, sensitivity_analysis_vars) {
+check_results <- function(wrangled_results_list, sensitivity_analysis_vars, risk_type) {
   sensitivity_analysis_vars <- paste0(sensitivity_analysis_vars, "_arg")
 
   # company trajectories ----------------------------------------------------
@@ -291,17 +292,32 @@ check_results <- function(wrangled_results_list, sensitivity_analysis_vars) {
   wrangled_results_list$crispy_output %>%
     report_missings(
       name_data = "CRISPY Results"
-    ) %>%
+    ) #%>%
+
+  if (risk_type == "trisk") {
+    wrangled_results_list$crispy_output <- wrangled_results_list$crispy_output %>%
+      report_all_duplicate_kinds(
+        composite_unique_cols = c(
+          "company_name", "sector", "business_unit", "roll_up_type",
+          "scenario_geography", "calculation_type", "baseline_scenario",
+          "shock_scenario", "lgd", "risk_free_rate", "discount_rate",
+          "dividend_rate", "growth_rate", "shock_year", "term"
+        )
+      )
+  }
+
+  if (risk_type == "lrisk") {
+  wrangled_results_list$crispy_output <- wrangled_results_list$crispy_output %>%
     report_all_duplicate_kinds(
       composite_unique_cols = c(
         "company_name", "sector", "business_unit", "roll_up_type",
         "scenario_geography", "calculation_type", "baseline_scenario",
         "shock_scenario", "lgd", "risk_free_rate", "discount_rate",
-        "dividend_rate", "growth_rate", "shock_year", "term", "scc",
-        "settlement_factor", "exp_share_damages_paid"
+        "dividend_rate", "growth_rate", "shock_year", "term",
+        "scc","settlement_factor", "exp_share_damages_paid"
       )
     )
-
+  }
   return(invisible(wrangled_results_list))
 }
 

--- a/R/wrangle_and_check.R
+++ b/R/wrangle_and_check.R
@@ -299,7 +299,7 @@ check_results <- function(wrangled_results_list, sensitivity_analysis_vars, risk
 
   if (risk_type == "lrisk") {
     composite_unique_cols_lrisk <- c("scc", "settlement_factor", "exp_share_damages_paid")
-    composite_unique_cols_crispy_results <- append(composite_unique_cols_crispy_results, composite_unique_cols_lrisk)
+    composite_unique_cols_crispy_results <- c(composite_unique_cols_crispy_results, composite_unique_cols_lrisk)
   }
 
   wrangled_results_list$crispy_output %>%
@@ -309,9 +309,6 @@ check_results <- function(wrangled_results_list, sensitivity_analysis_vars, risk
     report_all_duplicate_kinds(
       composite_unique_cols = composite_unique_cols_crispy_results
     )
-
-
-
 
   return(invisible(wrangled_results_list))
 }

--- a/R/wrangle_and_check.R
+++ b/R/wrangle_and_check.R
@@ -294,7 +294,8 @@ check_results <- function(wrangled_results_list, sensitivity_analysis_vars, risk
     "company_name", "sector", "business_unit", "roll_up_type",
     "scenario_geography", "calculation_type", "baseline_scenario",
     "shock_scenario", "lgd", "risk_free_rate", "discount_rate",
-    "dividend_rate", "growth_rate", "shock_year", "term")
+    "dividend_rate", "growth_rate", "shock_year", "term"
+  )
 
   if (risk_type == "lrisk") {
     composite_unique_cols_lrisk <- c("scc", "settlement_factor", "exp_share_damages_paid")
@@ -304,9 +305,10 @@ check_results <- function(wrangled_results_list, sensitivity_analysis_vars, risk
   wrangled_results_list$crispy_output %>%
     report_missings(
       name_data = "CRISPY Results"
-    )%>%
-      report_all_duplicate_kinds(
-        composite_unique_cols = composite_unique_cols_crispy_results)
+    ) %>%
+    report_all_duplicate_kinds(
+      composite_unique_cols = composite_unique_cols_crispy_results
+    )
 
 
 

--- a/R/wrangle_and_check.R
+++ b/R/wrangle_and_check.R
@@ -289,35 +289,28 @@ check_results <- function(wrangled_results_list, sensitivity_analysis_vars, risk
     )
 
   # crispy results ----------------------------------------------------
+
+  composite_unique_cols_crispy_results <- c(
+    "company_name", "sector", "business_unit", "roll_up_type",
+    "scenario_geography", "calculation_type", "baseline_scenario",
+    "shock_scenario", "lgd", "risk_free_rate", "discount_rate",
+    "dividend_rate", "growth_rate", "shock_year", "term")
+
+  if (risk_type == "lrisk") {
+    composite_unique_cols_lrisk <- c("scc", "settlement_factor", "exp_share_damages_paid")
+    composite_unique_cols_crispy_results <- append(composite_unique_cols_crispy_results, composite_unique_cols_lrisk)
+  }
+
   wrangled_results_list$crispy_output %>%
     report_missings(
       name_data = "CRISPY Results"
-    )
-
-  if (risk_type == "trisk") {
-    wrangled_results_list$crispy_output <- wrangled_results_list$crispy_output %>%
+    )%>%
       report_all_duplicate_kinds(
-        composite_unique_cols = c(
-          "company_name", "sector", "business_unit", "roll_up_type",
-          "scenario_geography", "calculation_type", "baseline_scenario",
-          "shock_scenario", "lgd", "risk_free_rate", "discount_rate",
-          "dividend_rate", "growth_rate", "shock_year", "term"
-        )
-      )
-  }
+        composite_unique_cols = composite_unique_cols_crispy_results)
 
-  if (risk_type == "lrisk") {
-    wrangled_results_list$crispy_output <- wrangled_results_list$crispy_output %>%
-      report_all_duplicate_kinds(
-        composite_unique_cols = c(
-          "company_name", "sector", "business_unit", "roll_up_type",
-          "scenario_geography", "calculation_type", "baseline_scenario",
-          "shock_scenario", "lgd", "risk_free_rate", "discount_rate",
-          "dividend_rate", "growth_rate", "shock_year", "term",
-          "scc", "settlement_factor", "exp_share_damages_paid"
-        )
-      )
-  }
+
+
+
   return(invisible(wrangled_results_list))
 }
 

--- a/man/aggregate_results.Rd
+++ b/man/aggregate_results.Rd
@@ -4,7 +4,7 @@
 \alias{aggregate_results}
 \title{Aggregate results}
 \usage{
-aggregate_results(results_list, sensitivity_analysis_vars, iter_var)
+aggregate_results(results_list, sensitivity_analysis_vars, iter_var, risk_type)
 }
 \arguments{
 \item{results_list}{A list of results.}
@@ -14,6 +14,8 @@ arguments.}
 
 \item{iter_var}{String vector holding the variable over which to iterate in
 sensitivity analysis}
+
+\item{risk_type}{String that is either lrisk or trisk}
 }
 \value{
 A list including basic and aggregated results.

--- a/man/check_results.Rd
+++ b/man/check_results.Rd
@@ -4,13 +4,15 @@
 \alias{check_results}
 \title{Check results}
 \usage{
-check_results(wrangled_results_list, sensitivity_analysis_vars)
+check_results(wrangled_results_list, sensitivity_analysis_vars, risk_type)
 }
 \arguments{
 \item{wrangled_results_list}{A list of wrangled results.}
 
 \item{sensitivity_analysis_vars}{String vector holding names of iteration
 arguments.}
+
+\item{risk_type}{String that is either lrisk or trisk.}
 }
 \value{
 \code{wrangled_results_list}


### PR DESCRIPTION
Adjusted code such that
- lrisk parameters scc exp_share_damages_paid settlement_factor are in crispy output and 
- that more values can be imputed at the same time 
New variable needed to distinct lrisk and trisk 
