### PR TITLE
Make ST code compatible to tidyselect 1.2

### DIFF
--- a/R/asset_value_at_risk.R
+++ b/R/asset_value_at_risk.R
@@ -72,7 +72,7 @@ asset_value_at_risk <- function(data,
         (.data$total_disc_npv_ls - .data$total_disc_npv_baseline) /
         .data$total_disc_npv_baseline
     ) %>%
-    dplyr::select(-c(.data$total_disc_npv_ls, .data$total_disc_npv_baseline))
+    dplyr::select(-all_of(c("total_disc_npv_ls", "total_disc_npv_baseline")))
 
   data <- data %>%
     dplyr::inner_join(
@@ -118,7 +118,7 @@ asset_value_at_risk <- function(data,
       year_of_shock = .env$shock_scenario$year_of_shock,
       production_shock_perc = NA_real_
     ) %>%
-    dplyr::select(-c(.data$plan_carsten, .data$plan_sec_carsten, .data$year))
+    dplyr::select(-all_of(c("plan_carsten", "plan_sec_carsten", "year")))
 
   return(data)
 }

--- a/R/asset_value_at_risk.R
+++ b/R/asset_value_at_risk.R
@@ -72,7 +72,7 @@ asset_value_at_risk <- function(data,
         (.data$total_disc_npv_ls - .data$total_disc_npv_baseline) /
         .data$total_disc_npv_baseline
     ) %>%
-    dplyr::select(-all_of(c("total_disc_npv_ls", "total_disc_npv_baseline")))
+    dplyr::select(-dplyr::all_of(c("total_disc_npv_ls", "total_disc_npv_baseline")))
 
   data <- data %>%
     dplyr::inner_join(
@@ -118,7 +118,7 @@ asset_value_at_risk <- function(data,
       year_of_shock = .env$shock_scenario$year_of_shock,
       production_shock_perc = NA_real_
     ) %>%
-    dplyr::select(-all_of(c("plan_carsten", "plan_sec_carsten", "year")))
+    dplyr::select(-dplyr::all_of(c("plan_carsten", "plan_sec_carsten", "year")))
 
   return(data)
 }

--- a/R/calculate_overall_pd_changes.R
+++ b/R/calculate_overall_pd_changes.R
@@ -44,7 +44,7 @@ calculate_pd_change_overall <- function(data,
     ) %>%
     dplyr::ungroup() %>%
     dplyr::select(
-      all_of(c("scenario_name", "scenario_geography", "id",
+      dplyr::all_of(c("scenario_name", "scenario_geography", "id",
       "company_name", "ald_sector", "equity_0_baseline",
       "equity_0_late_sudden", "debt_equity_ratio", "volatility")
       )

--- a/R/calculate_overall_pd_changes.R
+++ b/R/calculate_overall_pd_changes.R
@@ -44,9 +44,10 @@ calculate_pd_change_overall <- function(data,
     ) %>%
     dplyr::ungroup() %>%
     dplyr::select(
-      "scenario_name", "scenario_geography", "id",
+      all_of(c("scenario_name", "scenario_geography", "id",
       "company_name", "ald_sector", "equity_0_baseline",
-      "equity_0_late_sudden", "debt_equity_ratio", "volatility"
+      "equity_0_late_sudden", "debt_equity_ratio", "volatility")
+      )
     )
 
   data <- data %>%

--- a/R/calculate_overall_pd_changes.R
+++ b/R/calculate_overall_pd_changes.R
@@ -44,9 +44,9 @@ calculate_pd_change_overall <- function(data,
     ) %>%
     dplyr::ungroup() %>%
     dplyr::select(
-      .data$scenario_name, .data$scenario_geography, .data$id,
-      .data$company_name, .data$ald_sector, .data$equity_0_baseline,
-      .data$equity_0_late_sudden, .data$debt_equity_ratio, .data$volatility
+      "scenario_name", "scenario_geography", "id",
+      "company_name", "ald_sector", "equity_0_baseline",
+      "equity_0_late_sudden", "debt_equity_ratio", "volatility"
     )
 
   data <- data %>%
@@ -56,7 +56,7 @@ calculate_pd_change_overall <- function(data,
       # ADO 1943 - see nesting step below
       term = NA_integer_
     ) %>%
-    dplyr::select(-.data$debt_equity_ratio)
+    dplyr::select(-"debt_equity_ratio")
 
   nesting_names <- c(colnames(data %>% dplyr::select(-term)))
 

--- a/R/check_data.R
+++ b/R/check_data.R
@@ -44,7 +44,7 @@ check_level_availability <- function(data, data_name, expected_levels_list, thro
 check_sector_tech_mapping <- function(data, sector_col = "ald_sector",
                                       mapper_template = p4i_p4b_sector_technology_lookup) {
   sector_tech_mapper <- mapper_template %>%
-    dplyr::select(all_of(c("sector_p4i", "technology_p4i"))) %>%
+    dplyr::select(dplyr::all_of(c("sector_p4i", "technology_p4i"))) %>%
     dplyr::rename(ald_sector = "sector_p4i", technology = "technology_p4i") %>%
     dplyr::filter(.data$ald_sector %in% unique(get(sector_col, data)))
 

--- a/R/check_data.R
+++ b/R/check_data.R
@@ -44,8 +44,8 @@ check_level_availability <- function(data, data_name, expected_levels_list, thro
 check_sector_tech_mapping <- function(data, sector_col = "ald_sector",
                                       mapper_template = p4i_p4b_sector_technology_lookup) {
   sector_tech_mapper <- mapper_template %>%
-    dplyr::select(.data$sector_p4i, .data$technology_p4i) %>%
-    dplyr::rename(ald_sector = .data$sector_p4i, technology = .data$technology_p4i) %>%
+    dplyr::select(all_of(c("sector_p4i", "technology_p4i"))) %>%
+    dplyr::rename(ald_sector = "sector_p4i", technology = "technology_p4i") %>%
     dplyr::filter(.data$ald_sector %in% unique(get(sector_col, data)))
 
   additional_sector_tech_combinations <- data %>%

--- a/R/convert_cap_to_generation.R
+++ b/R/convert_cap_to_generation.R
@@ -55,7 +55,7 @@ convert_cap_to_generation <- function(data,
       ),
       scenario_geography = .data$scenario_geography
     ) %>%
-    dplyr::select(-.data$capacity_factor)
+    dplyr::select(-"capacity_factor")
 }
 
 #' Translate power capacity to power generation
@@ -111,10 +111,10 @@ convert_power_cap_to_generation <- function(data,
   capacity_factors_power <- capacity_factors_power %>%
     dplyr::filter(.data$scenario %in% c(baseline_scenario, target_scenario)) %>%
     tidyr::pivot_wider(
-      id_cols = c(.data$scenario_geography, .data$technology, .data$year),
-      names_from = .data$scenario,
+      id_cols = all_of(c("scenario_geography", "technology", "year")),
+      names_from = "scenario",
       names_prefix = "capfac_",
-      values_from = .data$capacity_factor
+      values_from = "capacity_factor"
     )
 
   # ADO 1945 - Left join is applied since only rows in data from ald_sector

--- a/R/convert_cap_to_generation.R
+++ b/R/convert_cap_to_generation.R
@@ -109,7 +109,7 @@ convert_power_cap_to_generation <- function(data,
   }
 
   capacity_factors_power <- capacity_factors_power %>%
-    dplyr::filter(scenario %in% c(baseline_scenario, target_scenario)) %>%
+    dplyr::filter(.data$scenario %in% c(baseline_scenario, target_scenario)) %>%
     tidyr::pivot_wider(
       id_cols = dplyr::all_of(c("scenario_geography", "technology", "year")),
       names_from = "scenario",

--- a/R/convert_cap_to_generation.R
+++ b/R/convert_cap_to_generation.R
@@ -109,7 +109,7 @@ convert_power_cap_to_generation <- function(data,
   }
 
   capacity_factors_power <- capacity_factors_power %>%
-    dplyr::filter(.data$scenario %in% c(baseline_scenario, target_scenario)) %>%
+    dplyr::filter(scenario %in% c(baseline_scenario, target_scenario)) %>%
     tidyr::pivot_wider(
       id_cols = all_of(c("scenario_geography", "technology", "year")),
       names_from = "scenario",

--- a/R/convert_cap_to_generation.R
+++ b/R/convert_cap_to_generation.R
@@ -111,7 +111,7 @@ convert_power_cap_to_generation <- function(data,
   capacity_factors_power <- capacity_factors_power %>%
     dplyr::filter(scenario %in% c(baseline_scenario, target_scenario)) %>%
     tidyr::pivot_wider(
-      id_cols = all_of(c("scenario_geography", "technology", "year")),
+      id_cols = dplyr::all_of(c("scenario_geography", "technology", "year")),
       names_from = "scenario",
       names_prefix = "capfac_",
       values_from = "capacity_factor"

--- a/R/extend_scenario_trajectory.R
+++ b/R/extend_scenario_trajectory.R
@@ -118,9 +118,10 @@ summarise_production_technology_forecasts <- function(data,
                                                       time_frame) {
   data <- data %>%
     dplyr::select(
-      "id", "company_name", "ald_sector", "technology",
+      all_of(c("id", "company_name", "ald_sector", "technology",
       "scenario_geography", "year", "plan_tech_prod",
-      "plan_emission_factor"
+      "plan_emission_factor")
+      )
     ) %>%
     dplyr::filter(.data$year <= .env$start_analysis + .env$time_frame) %>%
     dplyr::group_by(
@@ -195,7 +196,7 @@ extend_to_full_analysis_timeframe <- function(data,
       .data$plan_emission_factor
     ) %>%
     dplyr::rename(
-      emission_factor = .data$plan_emission_factor
+      emission_factor = "plan_emission_factor"
     )
 
   return(data)
@@ -320,9 +321,9 @@ calculate_proximity_to_target <- function(data,
       )
     ) %>%
     dplyr::select(
-      -c(
+      -all_of(c(
         "sum_required_change", "sum_realised_change",
-        "ratio_realised_required"
+        "ratio_realised_required")
       )
     )
 

--- a/R/extend_scenario_trajectory.R
+++ b/R/extend_scenario_trajectory.R
@@ -97,8 +97,8 @@ extend_scenario_trajectory <- function(data,
       values_from = "scen_tech_prod"
     ) %>%
     dplyr::arrange(
-      "id", "company_name", "scenario_geography", "ald_sector",
-      "technology", "year"
+      .data$id, .data$company_name, .data$scenario_geography, .data$ald_sector,
+      .data$technology, .data$year
     )
 
   return(data)
@@ -219,7 +219,7 @@ summarise_production_sector_forecasts <- function(data) {
     dplyr::mutate(
       plan_sec_prod = sum(.data$plan_tech_prod, na.rm = TRUE)
     ) %>%
-    dplyr::arrange("year") %>%
+    dplyr::arrange(.data$year) %>%
     dplyr::ungroup() %>%
     dplyr::group_by(
       .data$id, .data$company_name, .data$ald_sector, .data$scenario,

--- a/R/extend_scenario_trajectory.R
+++ b/R/extend_scenario_trajectory.R
@@ -88,11 +88,11 @@ extend_scenario_trajectory <- function(data,
 
   data <- data %>%
     tidyr::pivot_wider(
-      id_cols = c(
+      id_cols = dplyr::all_of(c(
         "id", "company_name", "year", "scenario_geography", "ald_sector",
         "technology", "plan_tech_prod", "phase_out", "emission_factor",
-        "proximity_to_target", "direction"
-      ),
+        "proximity_to_target", "direction")
+        ),
       names_from = "scenario",
       values_from = "scen_tech_prod"
     ) %>%

--- a/R/extend_scenario_trajectory.R
+++ b/R/extend_scenario_trajectory.R
@@ -118,7 +118,7 @@ summarise_production_technology_forecasts <- function(data,
                                                       time_frame) {
   data <- data %>%
     dplyr::select(
-      all_of(c("id", "company_name", "ald_sector", "technology",
+      dplyr::all_of(c("id", "company_name", "ald_sector", "technology",
       "scenario_geography", "year", "plan_tech_prod",
       "plan_emission_factor")
       )
@@ -190,7 +190,7 @@ extend_to_full_analysis_timeframe <- function(data,
       .data$scenario_geography, .data$year
     ) %>%
     tidyr::fill(
-      all_of(c("initial_technology_production",
+      dplyr::all_of(c("initial_technology_production",
                "final_technology_production",
                "phase_out",
                "plan_emission_factor")
@@ -322,7 +322,7 @@ calculate_proximity_to_target <- function(data,
       )
     ) %>%
     dplyr::select(
-      -all_of(c(
+      -dplyr::all_of(c(
         "sum_required_change", "sum_realised_change",
         "ratio_realised_required")
       )

--- a/R/extend_scenario_trajectory.R
+++ b/R/extend_scenario_trajectory.R
@@ -122,14 +122,14 @@ summarise_production_technology_forecasts <- function(data,
       "scenario_geography", "year", "plan_tech_prod",
       "plan_emission_factor"
     ) %>%
-    dplyr::filter("year" <= .env$start_analysis + .env$time_frame) %>%
+    dplyr::filter(.data$year <= .env$start_analysis + .env$time_frame) %>%
     dplyr::group_by(
-      "id", "company_name", "ald_sector", "technology",
-      "scenario_geography"
+      .data$id, .data$company_name, .data$ald_sector, .data$technology,
+      .data$scenario_geography
     ) %>%
     dplyr::arrange(
-      "id", "company_name", "ald_sector", "technology",
-      "scenario_geography", "year"
+      .data$id, .data$company_name, .data$ald_sector, .data$technology,
+      .data$scenario_geography, .data$year
     ) %>%
     dplyr::mutate(
       # Initial value is identical between production and scenario target,
@@ -153,8 +153,8 @@ identify_technology_phase_out <- function(data) {
   data <- data %>%
     dplyr::mutate(
       phase_out = dplyr::if_else(
-        "final_technology_production" == 0 &
-          "sum_production_forecast" > 0,
+        .data$final_technology_production == 0 &
+          .data$sum_production_forecast > 0,
         TRUE,
         FALSE
       )
@@ -185,17 +185,17 @@ extend_to_full_analysis_timeframe <- function(data,
       )
     ) %>%
     dplyr::arrange(
-      "id", "company_name", "ald_sector", "technology",
-      "scenario_geography", "year"
+      .data$id, .data$company_name, .data$ald_sector, .data$technology,
+      .data$scenario_geography, .data$year
     ) %>%
     tidyr::fill(
-      "initial_technology_production",
-      "final_technology_production",
-      "phase_out",
-      "plan_emission_factor"
+      .data$initial_technology_production,
+      .data$final_technology_production,
+      .data$phase_out,
+      .data$plan_emission_factor
     ) %>%
     dplyr::rename(
-      emission_factor = "plan_emission_factor"
+      emission_factor = .data$plan_emission_factor
     )
 
   return(data)
@@ -211,8 +211,8 @@ extend_to_full_analysis_timeframe <- function(data,
 summarise_production_sector_forecasts <- function(data) {
   data <- data %>%
     dplyr::group_by(
-      "id", "company_name", "ald_sector", "scenario",
-      "scenario_geography", "units", "year"
+      .data$id, .data$company_name, .data$ald_sector, .data$scenario,
+      .data$scenario_geography, .data$units, .data$year
     ) %>%
     dplyr::mutate(
       plan_sec_prod = sum(.data$plan_tech_prod, na.rm = TRUE)
@@ -220,13 +220,13 @@ summarise_production_sector_forecasts <- function(data) {
     dplyr::arrange("year") %>%
     dplyr::ungroup() %>%
     dplyr::group_by(
-      "id", "company_name", "ald_sector", "scenario",
-      "scenario_geography", "units"
+      .data$id, .data$company_name, .data$ald_sector, .data$scenario,
+      .data$scenario_geography, .data$units
     ) %>%
     dplyr::mutate(
       # first year plan and scenario values are equal by construction,
       # can thus be used for production and target
-      initial_sector_production = dplyr::first("plan_sec_prod")
+      initial_sector_production = dplyr::first(.data$plan_sec_prod)
     ) %>%
     dplyr::ungroup()
 }
@@ -242,7 +242,7 @@ apply_scenario_targets <- function(data) {
   data <- data %>%
     dplyr::mutate(
       scen_tech_prod = dplyr::if_else(
-        "direction" == "declining",
+        .data$direction == "declining",
         .data$initial_technology_production * (1 + .data$fair_share_perc), # tmsr
         .data$initial_technology_production + (.data$initial_sector_production * .data$fair_share_perc) # smsp
       )
@@ -262,9 +262,9 @@ handle_phase_out_and_negative_targets <- function(data) {
   data <- data %>%
     dplyr::mutate(
       scen_tech_prod = dplyr::case_when(
-        "scen_tech_prod" < 0 ~ 0,
-        "phase_out" == TRUE ~ 0,
-        TRUE ~ "scen_tech_prod"
+        .data$scen_tech_prod < 0 ~ 0,
+        .data$phase_out == TRUE ~ 0,
+        TRUE ~ .data$scen_tech_prod
       )
     )
 }
@@ -293,30 +293,30 @@ calculate_proximity_to_target <- function(data,
   production_changes <- data %>%
     dplyr::filter(
       dplyr::between(
-        "year", .env$start_analysis, .env$start_analysis + .env$time_frame
+        .data$year, .env$start_analysis, .env$start_analysis + .env$time_frame
       ),
-      "scenario" == .env$target_scenario
+      .data$scenario == .env$target_scenario
     ) %>%
     dplyr::group_by(
-      "id", "company_name", "ald_sector", "technology",
-      "scenario_geography"
+      .data$id, .data$company_name, .data$ald_sector, .data$technology,
+      .data$scenario_geography
     ) %>%
     dplyr::mutate(
-      required_change = "scen_tech_prod" - "initial_technology_production",
-      realised_change = "plan_tech_prod" - "initial_technology_production"
+      required_change = .data$scen_tech_prod - .data$initial_technology_production,
+      realised_change = .data$plan_tech_prod - .data$initial_technology_production
     ) %>%
     dplyr::summarise(
-      sum_required_change = sum("required_change", na.rm = TRUE),
-      sum_realised_change = sum("realised_change", na.rm = TRUE),
+      sum_required_change = sum(.data$required_change, na.rm = TRUE),
+      sum_realised_change = sum(.data$realised_change, na.rm = TRUE),
       .groups = "drop"
     ) %>%
     dplyr::ungroup() %>%
     dplyr::mutate(
-      ratio_realised_required = "sum_realised_change" / "sum_required_change",
+      ratio_realised_required = .data$sum_realised_change / .data$sum_required_change,
       proximity_to_target = dplyr::case_when(
-        "ratio_realised_required" < 0 ~ 0,
-        "ratio_realised_required" > 1 ~ 1,
-        TRUE ~ "ratio_realised_required"
+        .data$ratio_realised_required < 0 ~ 0,
+        .data$ratio_realised_required > 1 ~ 1,
+        TRUE ~ .data$ratio_realised_required
       )
     ) %>%
     dplyr::select(

--- a/R/extend_scenario_trajectory.R
+++ b/R/extend_scenario_trajectory.R
@@ -190,10 +190,11 @@ extend_to_full_analysis_timeframe <- function(data,
       .data$scenario_geography, .data$year
     ) %>%
     tidyr::fill(
-      .data$initial_technology_production,
-      .data$final_technology_production,
-      .data$phase_out,
-      .data$plan_emission_factor
+      all_of(c("initial_technology_production",
+               "final_technology_production",
+               "phase_out",
+               "plan_emission_factor")
+      )
     ) %>%
     dplyr::rename(
       emission_factor = "plan_emission_factor"

--- a/R/filter.R
+++ b/R/filter.R
@@ -29,7 +29,7 @@ keep_merton_compatible_rows <- function(data, stage) {
   data_filtered <- data %>%
     dplyr::filter(.data$risk_free_rate >= 0) %>%
     dplyr::filter(.data$debt > 0 & .data$V0_base > 0 & .data$V0_late_sudden > 0 & .data$volatility > 0 & .data$term > 0) %>%
-    dplyr::select(-.data$V0_base, -.data$V0_late_sudden)
+    dplyr::select(-all_of(c("V0_base", "V0_late_sudden")))
 
   if (nrow(data_filtered) < nrow(data)) {
     cat(paste0("Removed ", nrow(data) - nrow(data_filtered), " rows when checking for compatibility with merton model. \n"))

--- a/R/filter.R
+++ b/R/filter.R
@@ -29,7 +29,7 @@ keep_merton_compatible_rows <- function(data, stage) {
   data_filtered <- data %>%
     dplyr::filter(.data$risk_free_rate >= 0) %>%
     dplyr::filter(.data$debt > 0 & .data$V0_base > 0 & .data$V0_late_sudden > 0 & .data$volatility > 0 & .data$term > 0) %>%
-    dplyr::select(-all_of(c("V0_base", "V0_late_sudden")))
+    dplyr::select(-dplyr::all_of(c("V0_base", "V0_late_sudden")))
 
   if (nrow(data_filtered) < nrow(data)) {
     cat(paste0("Removed ", nrow(data) - nrow(data_filtered), " rows when checking for compatibility with merton model. \n"))

--- a/R/process_data.R
+++ b/R/process_data.R
@@ -172,7 +172,7 @@ remove_high_carbon_tech_with_missing_production <- function(data,
 
     # information on companies for which at least 1 technology is lost
     affected_company_sector_tech_overview <- companies_missing_high_carbon_tech_production %>%
-      dplyr::select(all_of(c("company_name", "ald_sector", "technology"))) %>%
+      dplyr::select(dplyr::all_of(c("company_name", "ald_sector", "technology"))) %>%
       dplyr::distinct_all()
 
     percent_affected_companies <- (length(unique(affected_company_sector_tech_overview$company_name)) * 100) / length(unique(data$company_name))

--- a/R/process_data.R
+++ b/R/process_data.R
@@ -172,7 +172,7 @@ remove_high_carbon_tech_with_missing_production <- function(data,
 
     # information on companies for which at least 1 technology is lost
     affected_company_sector_tech_overview <- companies_missing_high_carbon_tech_production %>%
-      dplyr::select(.data$company_name, .data$ald_sector, .data$technology) %>%
+      dplyr::select(all_of(c("company_name", "ald_sector", "technology"))) %>%
       dplyr::distinct_all()
 
     percent_affected_companies <- (length(unique(affected_company_sector_tech_overview$company_name)) * 100) / length(unique(data$company_name))

--- a/R/read_price_data.R
+++ b/R/read_price_data.R
@@ -32,7 +32,7 @@ read_price_data <- function(path) {
     # doing hardcoded filtering directly upon import as we currently do not
     # differentiate scenario_geographies for price data
     dplyr::filter(scenario_geography == "Global") %>%
-    dplyr::select(.data$year, .data$scenario, ald_sector = .data$sector, .data$technology, .data$price)
+    dplyr::select(all_of(c("year", "scenario", "ald_sector" = "sector", "technology", "price")))
 
   return(data)
 }

--- a/R/read_price_data.R
+++ b/R/read_price_data.R
@@ -32,7 +32,7 @@ read_price_data <- function(path) {
     # doing hardcoded filtering directly upon import as we currently do not
     # differentiate scenario_geographies for price data
     dplyr::filter(scenario_geography == "Global") %>%
-    dplyr::select(all_of(c("year", "scenario", "ald_sector" = "sector", "technology", "price")))
+    dplyr::select(dplyr::all_of(c("year", "scenario", "ald_sector" = "sector", "technology", "price")))
 
   return(data)
 }

--- a/R/set_tech_trajectories.R
+++ b/R/set_tech_trajectories.R
@@ -54,7 +54,7 @@ set_baseline_trajectory <- function(data,
     dplyr::ungroup()
 
   data <- data %>%
-    dplyr::select(-all_of(c("scenario_change", "scen_to_follow")))
+    dplyr::select(-dplyr::all_of(c("scenario_change", "scen_to_follow")))
 
   return(data)
 }
@@ -215,7 +215,7 @@ set_trisk_trajectory <- function(data,
     ) %>%
     dplyr::ungroup() %>%
     dplyr::select(
-      -all_of(c(
+      -dplyr::all_of(c(
         "scen_to_follow",
         "scenario_change",
         "scenario_change_baseline",
@@ -375,7 +375,7 @@ calc_late_sudden_traj <- function(start_year, end_year, year_of_shock, duration_
 filter_negative_late_and_sudden <- function(data_with_late_and_sudden, log_path) {
   negative_late_and_sudden <- data_with_late_and_sudden %>%
     dplyr::filter(.data$late_sudden < 0) %>%
-    dplyr::select(all_of(c("company_name", "technology"))) %>%
+    dplyr::select(dplyr::all_of(c("company_name", "technology"))) %>%
     dplyr::distinct()
 
   if (nrow(negative_late_and_sudden) > 0) {
@@ -497,7 +497,7 @@ set_litigation_trajectory <- function(data,
   reference <- data %>%
     dplyr::filter(.data$year == .env$start_year + .env$analysis_time_frame) %>%
     dplyr::select(
-      all_of(c("id", "company_name", "ald_sector", "technology",
+      dplyr::all_of(c("id", "company_name", "ald_sector", "technology",
       "scenario_geography", "plan_tech_prod"))
     ) %>%
     dplyr::rename(

--- a/R/set_tech_trajectories.R
+++ b/R/set_tech_trajectories.R
@@ -38,8 +38,8 @@ set_baseline_trajectory <- function(data,
 
   data <- data %>%
     dplyr::group_by(
-      "id", "company_name", "ald_sector", "technology",
-      "scenario_geography"
+      .data$id, .data$company_name, .data$ald_sector, .data$technology,
+      .data$scenario_geography
     ) %>%
     dplyr::mutate(
       scen_to_follow = !!rlang::sym(baseline_scenario)

--- a/R/set_tech_trajectories.R
+++ b/R/set_tech_trajectories.R
@@ -38,8 +38,8 @@ set_baseline_trajectory <- function(data,
 
   data <- data %>%
     dplyr::group_by(
-      .data$id, .data$company_name, .data$ald_sector, .data$technology,
-      .data$scenario_geography
+      "id", "company_name", "ald_sector", "technology",
+      "scenario_geography"
     ) %>%
     dplyr::mutate(
       scen_to_follow = !!rlang::sym(baseline_scenario)
@@ -54,7 +54,7 @@ set_baseline_trajectory <- function(data,
     dplyr::ungroup()
 
   data <- data %>%
-    dplyr::select(-c(.data$scenario_change, .data$scen_to_follow))
+    dplyr::select(-all_of(c("scenario_change", "scen_to_follow")))
 
   return(data)
 }
@@ -215,14 +215,14 @@ set_trisk_trajectory <- function(data,
     ) %>%
     dplyr::ungroup() %>%
     dplyr::select(
-      -c(
-        .data$scen_to_follow,
-        .data$scenario_change,
-        .data$scenario_change_baseline,
-        .data$scenario_change_aligned,
-        .data$overshoot_direction
+      -all_of(c(
+        "scen_to_follow",
+        "scenario_change",
+        "scenario_change_baseline",
+        "scenario_change_aligned",
+        "overshoot_direction"
       )
-    ) %>%
+    )) %>%
     dplyr::mutate(scenario_name = .env$scenario_name)
 
   data <- filter_negative_late_and_sudden(data, log_path = log_path)
@@ -375,7 +375,7 @@ calc_late_sudden_traj <- function(start_year, end_year, year_of_shock, duration_
 filter_negative_late_and_sudden <- function(data_with_late_and_sudden, log_path) {
   negative_late_and_sudden <- data_with_late_and_sudden %>%
     dplyr::filter(.data$late_sudden < 0) %>%
-    dplyr::select(.data$company_name, .data$technology) %>%
+    dplyr::select(all_of(c("company_name", "technology"))) %>%
     dplyr::distinct()
 
   if (nrow(negative_late_and_sudden) > 0) {
@@ -497,11 +497,11 @@ set_litigation_trajectory <- function(data,
   reference <- data %>%
     dplyr::filter(.data$year == .env$start_year + .env$analysis_time_frame) %>%
     dplyr::select(
-      .data$id, .data$company_name, .data$ald_sector, .data$technology,
-      .data$scenario_geography, .data$plan_tech_prod
+      all_of(c("id", "company_name", "ald_sector", "technology",
+      "scenario_geography", "plan_tech_prod"))
     ) %>%
     dplyr::rename(
-      reference_tech_prod = .data$plan_tech_prod
+      reference_tech_prod = "plan_tech_prod"
     )
 
   data <- data %>%
@@ -578,7 +578,7 @@ set_litigation_trajectory <- function(data,
     dplyr::group_by(.data$id, .data$company_name) %>%
     dplyr::mutate(company_is_litigated = any(.data$company_x_biz_unit_is_litigated)) %>%
     dplyr::ungroup() %>%
-    dplyr::select(-.data$company_x_biz_unit_is_litigated)
+    dplyr::select(-"company_x_biz_unit_is_litigated")
 
   data <- filter_negative_late_and_sudden(data, log_path = log_path)
 

--- a/tests/testthat/test-calculate_overall_pd_changes.R
+++ b/tests/testthat/test-calculate_overall_pd_changes.R
@@ -37,12 +37,12 @@ test_that("PD_changes point in expected direction", {
   expected_direction <- test_data %>%
     dplyr::filter(.data$year == filter_year) %>%
     dplyr::select(
-      .data$scenario_name,
-      .data$scenario_geography,
-      .data$company_name,
-      .data$ald_sector,
-      .data$discounted_net_profit_baseline,
-      .data$discounted_net_profit_ls
+      "scenario_name",
+      "scenario_geography",
+      "company_name",
+      "ald_sector",
+      "discounted_net_profit_baseline",
+      "discounted_net_profit_ls"
     ) %>%
     dplyr::mutate(
       pd_expected_rising = dplyr::if_else(

--- a/tests/testthat/test-calculate_overall_pd_changes.R
+++ b/tests/testthat/test-calculate_overall_pd_changes.R
@@ -37,12 +37,13 @@ test_that("PD_changes point in expected direction", {
   expected_direction <- test_data %>%
     dplyr::filter(.data$year == filter_year) %>%
     dplyr::select(
-      "scenario_name",
-      "scenario_geography",
-      "company_name",
-      "ald_sector",
-      "discounted_net_profit_baseline",
-      "discounted_net_profit_ls"
+      dplyr::all_of(c("scenario_name",
+               "scenario_geography",
+               "company_name",
+               "ald_sector",
+               "discounted_net_profit_baseline",
+               "discounted_net_profit_ls")
+      )
     ) %>%
     dplyr::mutate(
       pd_expected_rising = dplyr::if_else(


### PR DESCRIPTION
Pull request addressing the issue of [tidyselect 1.2 compatibility](https://github.com/2DegreesInvesting/Stress_Test_ProjectMGMT/issues/41).

- Changed all R files where there were rename(), select(), fill() or pivot_wider() functions that have tidyselect backend functions.
-  Changes:  .data$var to "var" or dplyr::all_of(c("var_1", "var_2")) if multiples variables