### PR TITLE
Ngfs end year lookup

### DIFF
--- a/R/calculate.R
+++ b/R/calculate.R
@@ -107,7 +107,7 @@ calculate_lrisk_trajectory <- function(input_data_list,
       shock_scenario = litigation_scenario,
       litigation_scenario_aligned = target_scenario,
       start_year = start_year,
-      end_year = end_year_lookup,
+      end_year = end_year,
       analysis_time_frame = time_horizon_lookup,
       log_path = log_path
     ) %>%

--- a/R/lookup.R
+++ b/R/lookup.R
@@ -18,8 +18,6 @@ prod_nesting_vars_lookup <- c(
 
 calculation_level_lookup <- "company"
 
-end_year_lookup <- 2040
-
 time_horizon_lookup <- 5
 
 flat_multiplier_lookup <- 1

--- a/R/process_data.R
+++ b/R/process_data.R
@@ -377,7 +377,7 @@ process_financial_data <- function(data) {
 
 st_process <- function(data, scenario_geography, baseline_scenario,
                        shock_scenario, sectors, technologies, start_year, carbon_price_model,
-                       log_path) {
+                       log_path,end_year) {
   scenarios_filter <- c(baseline_scenario, shock_scenario)
 
   df_price <- process_price_data(
@@ -385,14 +385,14 @@ st_process <- function(data, scenario_geography, baseline_scenario,
     technologies = technologies,
     sectors = sectors,
     start_year = start_year,
-    end_year = end_year_lookup,
+    end_year = end_year,
     scenarios_filter = scenarios_filter
   )
 
   scenario_data <- process_scenario_data(
     data$scenario_data,
     start_year = start_year,
-    end_year = end_year_lookup,
+    end_year = end_year,
     sectors = sectors,
     technologies = technologies,
     scenario_geography_filter = scenario_geography,
@@ -407,14 +407,14 @@ st_process <- function(data, scenario_geography, baseline_scenario,
   carbon_data <- process_carbon_data(
     data$carbon_data,
     start_year = start_year,
-    end_year = end_year_lookup,
+    end_year = end_year,
     carbon_price_model = carbon_price_model
   )
 
   production_data <- process_production_data(
     data$production_data,
     start_year = start_year,
-    end_year = end_year_lookup,
+    end_year = end_year,
     time_horizon = time_horizon_lookup,
     scenario_geography_filter = scenario_geography,
     sectors = sectors,
@@ -427,7 +427,7 @@ st_process <- function(data, scenario_geography, baseline_scenario,
     extend_scenario_trajectory(
       scenario_data = scenario_data,
       start_analysis = start_year,
-      end_analysis = end_year_lookup,
+      end_analysis = end_year,
       time_frame = time_horizon_lookup,
       target_scenario = shock_scenario
     )
@@ -440,7 +440,7 @@ st_process <- function(data, scenario_geography, baseline_scenario,
       scenario_geography_filter = scenario_geography,
       technologies = technologies,
       start_year = start_year,
-      end_year = end_year_lookup
+      end_year = end_year
     )
 
     # convert power capacity to generation

--- a/R/process_data.R
+++ b/R/process_data.R
@@ -377,7 +377,7 @@ process_financial_data <- function(data) {
 
 st_process <- function(data, scenario_geography, baseline_scenario,
                        shock_scenario, sectors, technologies, start_year, carbon_price_model,
-                       log_path,end_year) {
+                       log_path, end_year) {
   scenarios_filter <- c(baseline_scenario, shock_scenario)
 
   df_price <- process_price_data(

--- a/R/run_lrisk.R
+++ b/R/run_lrisk.R
@@ -165,7 +165,7 @@ run_lrisk_iteration <- function(args_list) {
 }
 
 # Avoid R CMD check NOTE: "Undefined global functions or variables"
-globalVariables(c(names(formals(run_lrisk)), "iter_var"))
+globalVariables(c(names(formals(run_lrisk)), "iter_var", "end_year"))
 
 read_and_process_and_calc_lrisk <- function(args_list) {
   list2env(args_list, envir = rlang::current_env())

--- a/R/run_lrisk.R
+++ b/R/run_lrisk.R
@@ -102,6 +102,9 @@ run_lrisk <- function(input_path,
     iter_var = iter_var
   )
 
+  args_list$end_year <- end_year_lookup(scenario_type = scenario_type)
+
+
   st_results_list <- run_lrisk_iteration(args_list)
 
   result_names <- names(st_results_list[[1]])
@@ -199,7 +202,8 @@ read_and_process_and_calc_lrisk <- function(args_list) {
       technologies = sectors_and_technologies_list$technologies,
       start_year = start_year,
       carbon_price_model = carbon_price_model,
-      log_path = log_path
+      log_path = log_path,
+      end_year = end_year
     )
 
   input_data_list <- list(
@@ -219,7 +223,7 @@ read_and_process_and_calc_lrisk <- function(args_list) {
 
   litigation_scenario <- generate_litigation_shocks(
     start_of_analysis = start_year,
-    end_of_analysis = end_year_lookup,
+    end_of_analysis = end_year,
     shock_year = shock_year,
     scc = scc,
     exp_share_damages_paid = exp_share_damages_paid
@@ -233,7 +237,7 @@ read_and_process_and_calc_lrisk <- function(args_list) {
     target_scenario = shock_scenario,
     litigation_scenario = litigation_scenario,
     start_year = start_year,
-    end_year = end_year_lookup,
+    end_year = end_year,
     time_horizon = time_horizon_lookup,
     log_path = log_path
   )
@@ -257,7 +261,7 @@ read_and_process_and_calc_lrisk <- function(args_list) {
     data = company_net_profits,
     baseline_scenario = baseline_scenario,
     shock_scenario = shock_scenario,
-    end_year = end_year_lookup,
+    end_year = end_year,
     discount_rate = discount_rate,
     growth_rate = growth_rate,
     log_path = log_path
@@ -278,7 +282,7 @@ read_and_process_and_calc_lrisk <- function(args_list) {
   company_pd_changes_overall <- company_annual_profits %>%
     calculate_pd_change_overall(
       shock_year = litigation_scenario$year_of_shock,
-      end_of_analysis = end_year_lookup,
+      end_of_analysis = end_year,
       risk_free_interest_rate = risk_free_rate
     )
 

--- a/R/run_trisk.R
+++ b/R/run_trisk.R
@@ -85,13 +85,17 @@ run_trisk <- function(input_path,
     shock_scenario = shock_scenario
   )
 
+
   args_list$output_path <- customise_output_path(
     output_path = args_list$output_path,
     iter_var = iter_var
   )
 
-  st_results_list <- run_stress_test_iteration(args_list)
+  args_list$end_year <- end_year_lookup(scenario_type = scenario_type)
 
+
+  st_results_list <- run_stress_test_iteration(args_list)
+browser()
   result_names <- names(st_results_list[[1]])
   st_results <- result_names %>%
     purrr::map(function(tib) {
@@ -150,7 +154,7 @@ run_stress_test_iteration <- function(args_list) {
 }
 
 # Avoid R CMD check NOTE: "Undefined global functions or variables"
-globalVariables(c(names(formals(run_trisk)), "iter_var"))
+globalVariables(c(names(formals(run_trisk)), "iter_var", "end_year"))
 
 read_and_process_and_calc <- function(args_list) {
   list2env(args_list, envir = rlang::current_env())
@@ -187,7 +191,8 @@ read_and_process_and_calc <- function(args_list) {
       technologies = sectors_and_technologies_list$technologies,
       start_year = start_year,
       carbon_price_model = carbon_price_model,
-      log_path = log_path
+      log_path = log_path,
+      end_year = end_year
     )
 
   input_data_list <- list(
@@ -207,7 +212,7 @@ read_and_process_and_calc <- function(args_list) {
 
   transition_scenario <- generate_transition_shocks(
     start_of_analysis = start_year,
-    end_of_analysis = end_year_lookup,
+    end_of_analysis = end_year,
     shock_year = shock_year
   )
 
@@ -219,7 +224,7 @@ read_and_process_and_calc <- function(args_list) {
     target_scenario = shock_scenario,
     transition_scenario = transition_scenario,
     start_year = start_year,
-    end_year = end_year_lookup,
+    end_year = end_year,
     time_horizon = time_horizon_lookup,
     log_path = log_path
   )
@@ -237,7 +242,7 @@ read_and_process_and_calc <- function(args_list) {
     data = company_net_profits,
     baseline_scenario = baseline_scenario,
     shock_scenario = shock_scenario,
-    end_year = end_year_lookup,
+    end_year = end_year,
     discount_rate = discount_rate,
     growth_rate = growth_rate,
     log_path = log_path
@@ -258,7 +263,7 @@ read_and_process_and_calc <- function(args_list) {
   company_pd_changes_overall <- company_annual_profits %>%
     calculate_pd_change_overall(
       shock_year = transition_scenario$year_of_shock,
-      end_of_analysis = end_year_lookup,
+      end_of_analysis = end_year,
       risk_free_interest_rate = risk_free_rate
     )
 

--- a/R/run_trisk.R
+++ b/R/run_trisk.R
@@ -95,7 +95,7 @@ run_trisk <- function(input_path,
 
 
   st_results_list <- run_stress_test_iteration(args_list)
-browser()
+  browser()
   result_names <- names(st_results_list[[1]])
   st_results <- result_names %>%
     purrr::map(function(tib) {

--- a/R/run_trisk.R
+++ b/R/run_trisk.R
@@ -95,7 +95,7 @@ run_trisk <- function(input_path,
 
 
   st_results_list <- run_stress_test_iteration(args_list)
-  browser()
+
   result_names <- names(st_results_list[[1]])
   st_results <- result_names %>%
     purrr::map(function(tib) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -482,9 +482,11 @@ infer_scenario_type <- function(baseline_scenario, shock_scenario) {
 }
 
 end_year_lookup <- function(scenario_type) {
-  return(2040)
+ end_year <-  as.numeric(2040)
 
   if (scenario_type == "is_ngfs") {
-    return(2060)
+    end_year <-  as.numeric(2060)
+
   }
+ return(end_year)
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -482,9 +482,9 @@ infer_scenario_type <- function(baseline_scenario, shock_scenario) {
 }
 
 end_year_lookup <- function(scenario_type) {
- return(2040)
+  return(2040)
 
-  if(scenario_type == "is_ngfs")
- return(2060)
-
+  if (scenario_type == "is_ngfs") {
+    return(2060)
+  }
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -482,11 +482,10 @@ infer_scenario_type <- function(baseline_scenario, shock_scenario) {
 }
 
 end_year_lookup <- function(scenario_type) {
- end_year <-  as.numeric(2040)
+  end_year <- as.numeric(2040)
 
   if (scenario_type == "is_ngfs") {
-    end_year <-  as.numeric(2060)
-
+    end_year <- as.numeric(2060)
   }
- return(end_year)
+  return(end_year)
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -480,3 +480,11 @@ infer_scenario_type <- function(baseline_scenario, shock_scenario) {
     )
   }
 }
+
+end_year_lookup <- function(scenario_type) {
+ return(2040)
+
+  if(scenario_type == "is_ngfs")
+ return(2060)
+
+}

--- a/tests/testthat/test-financial_functions.R
+++ b/tests/testthat/test-financial_functions.R
@@ -148,7 +148,6 @@ test_that("calculate_net_profits does not apply carbon tax for low
 
 
   test_shock_year <- 2021
-  test_end_year_lookup <- 2040
 
   net_profits <- calculate_net_profits(input_data,
     carbon_data = carbon_data_test,


### PR DESCRIPTION
this pr adds an end_year function that is either 2040 or 2060 depending on the scenario type 
at the moment snap shot tests fail as end_year_arg is carried into the result list. should i prevent this from happening or is this in fact nice to have? cant decide 