### PR TITLE
Negativeprod

### DIFF
--- a/R/set_tech_trajectories.R
+++ b/R/set_tech_trajectories.R
@@ -53,6 +53,14 @@ set_baseline_trajectory <- function(data,
     ) %>%
     dplyr::ungroup()
 
+  # Negative Production Adjustment: when Baseline Production goes below 0, it stays at 0
+  data <- data %>%
+    dplyr::group_by(.data$id, .data$company_name, .data$ald_sector, .data$technology, .data$scenario_geography, .data$year) %>%
+    dplyr::mutate(baseline_adj = dplyr::if_else(.data$baseline < 0 & dplyr::lag(.data$baseline, default = 0) >= 0, 0, .data$baseline)) %>%
+    dplyr::ungroup() %>%
+    dplyr::select(-baseline) %>%
+    dplyr::rename(baseline = baseline_adj)
+
   data <- data %>%
     dplyr::select(-dplyr::all_of(c("scenario_change", "scen_to_follow")))
 

--- a/R/set_tech_trajectories.R
+++ b/R/set_tech_trajectories.R
@@ -59,7 +59,7 @@ set_baseline_trajectory <- function(data,
     dplyr::mutate(baseline_adj = dplyr::if_else(.data$baseline < 0 & dplyr::lag(.data$baseline, default = 0) >= 0, 0, .data$baseline)) %>%
     dplyr::ungroup() %>%
     dplyr::select(-baseline) %>%
-    dplyr::rename(baseline = baseline_adj)
+    dplyr::rename(baseline = .data$baseline_adj)
 
   data <- data %>%
     dplyr::select(-dplyr::all_of(c("scenario_change", "scen_to_follow")))
@@ -361,9 +361,18 @@ calc_late_sudden_traj <- function(start_year, end_year, year_of_shock, duration_
     # company plans are already aligned
     # no need for overshoot in production cap, set LS trajectory to follow
     # the scenario indicated as late & sudden aligned
+    # Negative Production Adjustment: If shock production gets negative, it is set to 0 and
+    # all future shock production is also set to 0
+    # same procedure if the last year of shock production is negative
 
     for (k in seq(first_production_na, length(scen_to_follow))) {
       late_and_sudden[k] <- late_and_sudden[k - 1] + scenario_change_aligned[k]
+      if (k == length(scen_to_follow) && late_and_sudden[k] < 0) {
+        late_and_sudden[k] <- 0
+      } else if (late_and_sudden[k] < 0) {
+        late_and_sudden[k] <- 0
+        late_and_sudden[(k+1):length(scen_to_follow)] <- 0
+      }
     }
   }
   return(late_and_sudden)


### PR DESCRIPTION
PR aims to do 2 things: 
1.if baseline production at [t] is below 0, then the baseline production at [t] is set to 0 and all [t+] are also set to 0
-> this happens for i.e. coal firms that have massively reduced production in the  year ahead period. the Baselien pathway is however calculated based on the value in 2021. 

2. if late_sudden production at [t] is below 0, then late_sudden is also set to 0 at [t] and all the following years. 
-> this happens because aligned companies shock pathway is set parallel to the target pathway. 

I did a check already for NGFS GCAM and this PR will affect around 8000 of 159000 output rows.