### PR TITLE
Negativeproductionv2

### DIFF
--- a/R/process_data.R
+++ b/R/process_data.R
@@ -169,7 +169,6 @@ remove_high_carbon_tech_with_missing_production <- function(data,
     )
 
   if (nrow(companies_missing_high_carbon_tech_production) > 0) {
-
     # information on companies for which at least 1 technology is lost
     affected_company_sector_tech_overview <- companies_missing_high_carbon_tech_production %>%
       dplyr::select(dplyr::all_of(c("company_name", "ald_sector", "technology"))) %>%
@@ -253,7 +252,6 @@ harmonise_cap_fac_geo_names <- function(data) {
 #' @noRd
 process_price_data <- function(data, technologies, sectors, start_year, end_year,
                                scenarios_filter) {
-
   # adding dummy unit price data for automotive data
   if ("Automotive" %in% sectors) {
     auto_tech <- p4i_p4b_sector_technology_lookup %>%

--- a/R/read.R
+++ b/R/read.R
@@ -1,5 +1,4 @@
 st_read_agnostic <- function(dir, start_year, sectors, risk_type) {
-
   # capacity_factors are only needed for power sector
   if ("Power" %in% sectors) {
     capacity_factors_power <- read_capacity_factors_power(capacity_factor_file(dir))

--- a/R/set_tech_trajectories.R
+++ b/R/set_tech_trajectories.R
@@ -371,7 +371,7 @@ calc_late_sudden_traj <- function(start_year, end_year, year_of_shock, duration_
         late_and_sudden[k] <- 0
       } else if (late_and_sudden[k] < 0) {
         late_and_sudden[k] <- 0
-        late_and_sudden[(k+1):length(scen_to_follow)] <- 0
+        late_and_sudden[(k + 1):length(scen_to_follow)] <- 0
       }
     }
   }

--- a/R/set_tech_trajectories.R
+++ b/R/set_tech_trajectories.R
@@ -361,9 +361,18 @@ calc_late_sudden_traj <- function(start_year, end_year, year_of_shock, duration_
     # company plans are already aligned
     # no need for overshoot in production cap, set LS trajectory to follow
     # the scenario indicated as late & sudden aligned
+    # Negative Production Adjustment: If shock production gets negative, it is set to 0 and
+    # all future shock production is also set to 0
+    # same procedure if the last year of shock production is negative
 
     for (k in seq(first_production_na, length(scen_to_follow))) {
       late_and_sudden[k] <- late_and_sudden[k - 1] + scenario_change_aligned[k]
+      if (k == length(scen_to_follow) && late_and_sudden[k] < 0) {
+        late_and_sudden[k] <- 0
+      } else if (late_and_sudden[k] < 0) {
+        late_and_sudden[k] <- 0
+        late_and_sudden[(k+1):length(scen_to_follow)] <- 0
+      }
     }
   }
   return(late_and_sudden)

--- a/R/set_tech_trajectories.R
+++ b/R/set_tech_trajectories.R
@@ -53,6 +53,14 @@ set_baseline_trajectory <- function(data,
     ) %>%
     dplyr::ungroup()
 
+  # Negative Production Adjustment: when Baseline Production goes below 0, it stays at 0
+  data <- data %>%
+    dplyr::group_by(.data$id, .data$company_name, .data$ald_sector, .data$technology, .data$scenario_geography, .data$year) %>%
+    dplyr::mutate(baseline_adj = dplyr::if_else(.data$baseline < 0 & dplyr::lag(.data$baseline, default = 0) >= 0, 0, .data$baseline)) %>%
+    dplyr::ungroup() %>%
+    dplyr::select(-baseline) %>%
+    dplyr::rename(baseline = .data$baseline_adj)
+
   data <- data %>%
     dplyr::select(-dplyr::all_of(c("scenario_change", "scen_to_follow")))
 

--- a/R/stress_test_model_functions.R
+++ b/R/stress_test_model_functions.R
@@ -39,7 +39,6 @@ join_price_data <- function(df, df_prices) {
 }
 
 dcf_model_techlevel <- function(data, discount_rate) {
-
   # Calculates the annual discounted net profits on technology level
   data %>%
     dplyr::group_by(investor_name, portfolio_name, id, company_name, ald_sector, technology, scenario_geography) %>%

--- a/R/wrangle_and_check.R
+++ b/R/wrangle_and_check.R
@@ -223,10 +223,11 @@ wrangle_results <- function(results_list, sensitivity_analysis_vars, risk_type) 
   if (risk_type == "lrisk") {
     select_cols <- c(merge_by_cols, "technology", "company_is_litigated", "settlement")
     crispy_output <- crispy_output %>%
-      dplyr::inner_join(results_list$company_trajectories %>%
-        dplyr::select(!!select_cols) %>%
-        dplyr::distinct_all(),
-      by = c(merge_by_cols, "technology") # inlcuding since settlement is a technology level variable
+      dplyr::inner_join(
+        results_list$company_trajectories %>%
+          dplyr::select(!!select_cols) %>%
+          dplyr::distinct_all(),
+        by = c(merge_by_cols, "technology") # inlcuding since settlement is a technology level variable
       )
 
     crispy_output <- crispy_output %>%

--- a/README.Rmd
+++ b/README.Rmd
@@ -64,7 +64,6 @@ run_lrisk(
   output_path = "/example_project/output",
   risk_free_rate = c(0.01, 0.03)
 )
-
 ```
 
 ## Details

--- a/tests/testthat/test-validate.R
+++ b/tests/testthat/test-validate.R
@@ -1,6 +1,5 @@
 # validate_input_values ---------------------------------------------------
 test_that("Error is thrown if input values are of incorrect type", {
-
   # numeric
   expect_error(validate_input_values(
     baseline_scenario = "WEO2021_STEPS",
@@ -76,7 +75,6 @@ test_that("Error is thrown if input values are of incorrect type for input value
 
 
 test_that("Error is thrown if an input value is out of bounds", {
-
   # length = 1
   expect_error(validate_input_values(
     baseline_scenario = "WEO2021_STEPS",
@@ -133,7 +131,6 @@ test_that("Error is thrown if an input value is out of bounds", {
 })
 
 test_that("Error is thrown if a character input value is out of bounds", {
-
   # length = 1
   expect_error(validate_input_values(
     baseline_scenario = "WEO2000_STEPS",

--- a/vignettes/articles/03-advanced-data-settings.Rmd
+++ b/vignettes/articles/03-advanced-data-settings.Rmd
@@ -76,14 +76,15 @@ validate_file_exists(loans_results_company_file_path)
 data <- readr::read_rds(loans_results_company_file_path)
 fin_companies <- data %>%
   dplyr::select(company_name) %>%
-  dplyr::distinct() %>% 
+  dplyr::distinct() %>%
   dplyr::mutate(
-    company_id = 999, 
+    company_id = 999,
     corporate_bond_ticker = NA,
     pd = NA,
     net_profit_margin = NA,
     debt_equity_ratio = NA,
-    volatility = NA)
+    volatility = NA
+  )
 readr::write_csv(fin_companies, file.path("/example_project/project_agnostic_input", "prewrangled_financial_data_stress_test.csv")) # NOTE that this will overwrite financial data currently stored at the location if available
 ```
 
@@ -101,12 +102,13 @@ messages in case problems are detected.
 library(readr)
 library(r2dii.climate.stress.test)
 
-financial_data_path <- file.path("/example_project/project_agnostic_input",
-                                 "prewrangled_financial_data_stress_test.csv")
+financial_data_path <- file.path(
+  "/example_project/project_agnostic_input",
+  "prewrangled_financial_data_stress_test.csv"
+)
 validate_file_exists(financial_data_path)
 data <- readr::read_csv(financial_data_path)
 check_financial_data(financial_data = data, asset_type = "loans", interactive_mode = TRUE)
-
 ```
 
 ### Placing file in folder structure


### PR DESCRIPTION
PR aims to do 2 things:
1.if baseline production at [t] is below 0, then the baseline production at [t] is set to 0 and all [t+] are also set to 0
-> this happens for i.e. coal firms that have massively reduced production in the year ahead period. the Baselien pathway is however calculated based on the value in 2021.
2.	if late_sudden production at [t] is below 0, then late_sudden is also set to 0 at [t] and all the following years.
-> this happens because aligned companies shock pathway is set parallel to the target pathway.
I did a check already for NGFS GCAM and this PR will affect around 8000 of 159000 output rows.


I also ran usethis::use_tidy_style() and addded the suggested changes