### PR TITLE
Negative Production Adjustment

### DIFF
--- a/R/set_tech_trajectories.R
+++ b/R/set_tech_trajectories.R
@@ -361,9 +361,15 @@ calc_late_sudden_traj <- function(start_year, end_year, year_of_shock, duration_
     # company plans are already aligned
     # no need for overshoot in production cap, set LS trajectory to follow
     # the scenario indicated as late & sudden aligned
+    # negative production adjustment: if shock production goes below 0
+    # then this and future production stays constant at 0.
 
     for (k in seq(first_production_na, length(scen_to_follow))) {
       late_and_sudden[k] <- late_and_sudden[k - 1] + scenario_change_aligned[k]
+      if (late_and_sudden[k] < 0) {
+        late_and_sudden[k:length(late_and_sudden)] <- 0
+        break
+      }
     }
   }
   return(late_and_sudden)

--- a/R/set_tech_trajectories.R
+++ b/R/set_tech_trajectories.R
@@ -53,6 +53,14 @@ set_baseline_trajectory <- function(data,
     ) %>%
     dplyr::ungroup()
 
+  # Negative Production Adjustment: when Baseline Production goes below 0, it stays at 0
+  data <- data %>%
+    dplyr::group_by(.data$id, .data$company_name, .data$ald_sector, .data$technology, .data$scenario_geography, .data$year) %>%
+    dplyr::mutate(baseline_adj = dplyr::if_else(.data$baseline < 0 & dplyr::lag(.data$baseline, default = 0) >= 0, 0, .data$baseline)) %>%
+    dplyr::ungroup() %>%
+    dplyr::select(-baseline) %>%
+    dplyr::rename(baseline = .data$baseline_adj)
+
   data <- data %>%
     dplyr::select(-dplyr::all_of(c("scenario_change", "scen_to_follow")))
 


### PR DESCRIPTION
PR aims to do 2 things:
1.if baseline production at [t] is below 0, then the baseline production at [t] is set to 0 and all [t+] are also set to 0
-> this happens for i.e. coal firms that have massively reduced production in the year ahead period. The Baseline pathway is however calculated based on the value in 2021.
2. if late_sudden production at [t] is below 0, then late_sudden is also set to 0 at [t] and all the following years.
-> this happens because aligned companies shock pathway is set parallel to the target pathway.

This will affect the snapshot results. Note that this will not affect the all companies, and hence the outputs will only differ for a couple of rows.
Affected columns are especially: PD_Shock
NPV_shock might also be affected, but any affect should be very low.

The effect on the affected companies can be positive and negative:
Example Positive effect:
Company A has Oil and Gas production. On previous model version, Oil Production has negative production values in the shock pathway, and is thus dropped from the analysis. PD is only calculated on Gas.
With this PR, the Oil business of company A will be included in the analysis. PD is then calculated on Gas and Oil. If the Oil is less heavily affected than Gas, then the overall situation of the company will be better and the PD_shock will decrease (and vice versa).

I ran styler, but styler did not change any relevant files.

