### PR TITLE
Time Frame change for Overshoot Direction

### DIFF
--- a/R/set_tech_trajectories.R
+++ b/R/set_tech_trajectories.R
@@ -333,8 +333,8 @@ calc_late_sudden_traj <- function(start_year, end_year, year_of_shock, duration_
   # we do not need to compensate production capacity, and set LS trajectory to follow
   # the scenario indicated as late & sudden aligned
   if (
-    (overshoot_direction == "Decreasing" & sum(scen_to_follow[1:time_frame]) < sum(late_and_sudden[1:time_frame])) |
-      (overshoot_direction == "Increasing" & sum(scen_to_follow[1:time_frame]) > sum(late_and_sudden[1:time_frame]))
+    (overshoot_direction == "Decreasing" & sum(scen_to_follow[1:time_frame+1]) < sum(late_and_sudden[1:time_frame+1])) |
+      (overshoot_direction == "Increasing" & sum(scen_to_follow[1:time_frame+1]) > sum(late_and_sudden[1:time_frame+1]))
   ) {
     x <- (
       sum(scen_to_follow) -

--- a/R/utils.R
+++ b/R/utils.R
@@ -499,7 +499,7 @@ end_year_lookup <- function(scenario_type) {
   end_year <- as.numeric(2040)
 
   if (scenario_type %in% c("is_ngfs", "is_oxford", "is_ipr")) {
-    end_year <- as.numeric(2100)
+    end_year <- as.numeric(2050)
   }
 
   return(end_year)


### PR DESCRIPTION
The timeframe for the overshoot direction is set at 1:5, which takes into account the years from 2021 till 2025. However, we need to consider all 5 years of foreward looking production data, so including 2026. 

I added a simple +1 to the time_frame variable, as time_frame is also used differently in other locations. 

Time Horizon is also changed to 2050, which should be pushed in a different PR into master soon. 

Note: This will affect the snapshot tests, but only to a limited degree. For most companies, it should make no difference. 